### PR TITLE
更新node-sass和增加跨平台执行npm run build的环境变量问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "private": true,
   "scripts": {
     "dev": "node build/dev-server.js",
-    "build:prod": "NODE_ENV=production node build/build.js",
-    "build:sit": "NODE_ENV=sit node build/build.js",
-    "build:sit-preview": "NODE_ENV=sit npm_config_preview=true  npm_config_report=true node build/build.js",
+    "build:prod": "cross-env NODE_ENV=production node build/build.js",
+    "build:sit": "cross-env NODE_ENV=sit node build/build.js",
+    "build:sit-preview": "cross-env NODE_ENV=sit npm_config_preview=true  npm_config_report=true node build/build.js",
     "lint": "eslint --ext .js,.vue src"
   },
   "dependencies": {
@@ -49,6 +49,7 @@
     "chalk": "1.1.3",
     "connect-history-api-fallback": "1.3.0",
     "copy-webpack-plugin": "4.0.1",
+    "cross-env": "^4.0.0",
     "css-loader": "0.26.1",
     "eslint": "3.14.1",
     "eslint-config-airbnb-base": "11.0.1",
@@ -65,7 +66,7 @@
     "function-bind": "1.1.0",
     "html-webpack-plugin": "2.28.0",
     "http-proxy-middleware": "0.17.3",
-    "node-sass": "3.7.0",
+    "node-sass": "4.5.2",
     "opn": "4.0.2",
     "optimize-css-assets-webpack-plugin": "1.3.0",
     "ora": "1.1.0",


### PR DESCRIPTION
解决windows10 64bit 下 sass 编译报错，和跨平台下的执行 npm run build:xxx 错误