### PR TITLE
fix: fix undone NProgress in hash mode

### DIFF
--- a/src/permission.js
+++ b/src/permission.js
@@ -18,6 +18,7 @@ router.beforeEach((to, from, next) => {
   if (getToken()) { // 判断是否有token
     if (to.path === '/login') {
       next({ path: '/' })
+      NProgress.done()
     } else {
       if (store.getters.roles.length === 0) { // 判断当前用户是否已拉取完user_info信息
         store.dispatch('GetUserInfo').then(res => { // 拉取user_info
@@ -37,6 +38,7 @@ router.beforeEach((to, from, next) => {
           next()//
         } else {
           next({ path: '/401', query: { noGoBack: true }})
+          NProgress.done()
         }
         // 可删 ↑
       }


### PR DESCRIPTION
发现两种情况会导致NProgress无法正确结束：
1、已登录时手动修改hash至login
2、动态修改权限后，进入没有权限的页面，点击浏览器的后退