### PR TITLE
get real version from node_modules

### DIFF
--- a/src/components/ThemePicker/index.vue
+++ b/src/components/ThemePicker/index.vue
@@ -6,9 +6,8 @@
 </template>
 
 <script>
-import { getVersion } from '@/utils/index.js'
 
-const version = getVersion('element-ui') // element-ui version from package.json
+const version = require('element-ui/package.json').version // element-ui version from node_modules
 const ORIGINAL_THEME = '#409EFF' // default color
 
 export default {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -265,9 +265,3 @@ export function deepClone(source) {
   }
   return targetObj
 }
-
-// get dependencies verison from package.json
-export function getVersion(name) {
-  const p = require('../../package')
-  return p.dependencies[name]
-}


### PR DESCRIPTION
1. 当使用`"element-ui": "^2.0.7"`时，原[getVersion](https://github.com/PanJiaChen/vue-element-admin/compare/master...lvsmart:master#diff-8968c62593320351ced6a0ef776ef599L270)方法返回`^2.0.7`，导致获取`index.css`出错
2. 原注释：`verison`拼写错误
3. 从node_modules直接获取element-ui版本号，更加直接，准确。