### PR TITLE
修复store中删除缓存的bug

### DIFF
--- a/src/store/modules/tagsView.js
+++ b/src/store/modules/tagsView.js
@@ -25,7 +25,7 @@ const tagsView = {
       for (const i of state.cachedViews) {
         if (i === view.name) {
           const index = state.cachedViews.indexOf(i)
-          state.cachedViews.splice(index, 1)
+          state.cachedViews.splice(index, index + 1)
           break
         }
       }


### PR DESCRIPTION
经测试，在store中 modules/tagsView.js，删除缓存页面原写法有问题
源代码const index = state.cachedViews.indexOf(i)
state.cachedViews = state.cachedViews.slice(index, i + 1)
应为
const index = state.cachedViews.indexOf(i)
state.cachedViews = state.cachedViews.slice(index, index + 1)