### PR TITLE
优化侧边菜单栏子菜单只有一个需要显示时，还需展开的问题

### DIFF
--- a/src/views/layout/components/Sidebar/SidebarItem.vue
+++ b/src/views/layout/components/Sidebar/SidebarItem.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="menu-wrapper">
-    <template v-for="item in routes" v-if="!item.hidden&&item.children">
+    <template v-for="item in _routes" v-if="!item.hidden&&item.children">
 
-      <router-link v-if="item.children.length===1 && !item.children[0].children&&!item.alwaysShow" :to="item.path+'/'+item.children[0].path" :key="item.children[0].name">
+      <router-link v-if="item.oneItem&&!item.alwaysShow" :to="item.path+'/'+item.children[0].path" :key="item.children[0].name">
         <el-menu-item :index="item.path+'/'+item.children[0].path" :class="{'submenu-title-noDropdown':!isNest}">
           <svg-icon v-if="item.children[0].meta&&item.children[0].meta.icon" :icon-class="item.children[0].meta.icon"></svg-icon>
           <span v-if="item.children[0].meta&&item.children[0].meta.title">{{generateTitle(item.children[0].meta.title)}}</span>
@@ -43,6 +43,17 @@ export default {
     isNest: {
       type: Boolean,
       default: false
+    }
+  },
+  computed: {
+    _routes() {
+      return this.routes.map(item => {
+        item.oneItem = false
+        if (item.children) {
+          item.oneItem = item.children.filter(_item => !_item.hidden).length === 1
+        }
+        return item
+      })
     }
   },
   methods: {


### PR DESCRIPTION
如果侧边栏子项只有一个为需要显示，其它都不需要显示。那么这个菜单就不需要再展开显示了。