### PR TITLE
fix: misplaced script tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,8 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
 		<title>vue-element-admin</title>
 	</head>
-	<script src=<%= htmlWebpackPlugin.options.path %>/tinymce4.7.5/tinymce.min.js></script>
 	<body>
+		<script src=<%= htmlWebpackPlugin.options.path %>/tinymce4.7.5/tinymce.min.js></script>
 		<div id="app"></div>
 		<!-- built files will be auto injected -->
 	</body>


### PR DESCRIPTION
Originally the script tag was in the body tag, but moved to the outside by f2fcdee.