### PR TITLE
Update themepick/index.vue

### DIFF
--- a/src/components/ThemePicker/index.vue
+++ b/src/components/ThemePicker/index.vue
@@ -69,7 +69,8 @@ export default {
       const colorOverrides = [] // only capture color overides
       oldCluster.forEach((color, index) => {
         const value = newCluster[index]
-        const repl = new RegExp(`(^|})([^{]+{[^{}]+)${color}\\b([^}]*)(?=})`, 'gi')
+        const color_plain = color.replace(/([()])/g,'\\$1')
+        const repl = new RegExp(`(^|})([^{]+{[^{}]+)${color_plain}\\b([^}]*)(?=})`, 'gi')
         const nestRepl = new RegExp(color, 'ig') // for greed matching before the 'color'
         let v
         while ((v = repl.exec(style))) {

--- a/src/components/ThemePicker/index.vue
+++ b/src/components/ThemePicker/index.vue
@@ -69,7 +69,7 @@ export default {
       const colorOverrides = [] // only capture color overides
       oldCluster.forEach((color, index) => {
         const value = newCluster[index]
-        const color_plain = color.replace(/([()])/g,'\\$1')
+        const color_plain = color.replace(/([()])/g, '\\$1')
         const repl = new RegExp(`(^|})([^{]+{[^{}]+)${color_plain}\\b([^}]*)(?=})`, 'gi')
         const nestRepl = new RegExp(color_plain, 'ig') // for greed matching before the 'color'
         let v

--- a/src/components/ThemePicker/index.vue
+++ b/src/components/ThemePicker/index.vue
@@ -65,7 +65,7 @@ export default {
   },
 
   methods: {
-    updateStyle(style, oldCluster, newCluster) {      
+    updateStyle(style, oldCluster, newCluster) {
       let colorOverrides = [] // only capture color overides
       oldCluster.forEach((color, index) => {
         let value = newCluster[index]

--- a/src/components/ThemePicker/index.vue
+++ b/src/components/ThemePicker/index.vue
@@ -72,7 +72,7 @@ export default {
         let repl = new RegExp(`(^|})([^{]+{[^{}]+)${color}\\b([^}]*)(?=})`, 'gi')
         let nestRepl = new RegExp(color, 'ig') // for greed matching before the 'color'
         let v
-        while ((v = repl.exec(data))) {
+        while ((v = repl.exec(style))) {
           colorOverrides.push(v[2].replace(nestRepl, value) + value + v[3] + '}') // '}' not captured in the regexp repl to reserve it as locator-boundary
         }
       })

--- a/src/components/ThemePicker/index.vue
+++ b/src/components/ThemePicker/index.vue
@@ -71,7 +71,7 @@ export default {
         const value = newCluster[index]
         const color_plain = color.replace(/([()])/g,'\\$1')
         const repl = new RegExp(`(^|})([^{]+{[^{}]+)${color_plain}\\b([^}]*)(?=})`, 'gi')
-        const nestRepl = new RegExp(color, 'ig') // for greed matching before the 'color'
+        const nestRepl = new RegExp(color_plain, 'ig') // for greed matching before the 'color'
         let v
         while ((v = repl.exec(style))) {
           colorOverrides.push(v[2].replace(nestRepl, value) + value + v[3] + '}') // '}' not captured in the regexp repl to reserve it as locator-boundary

--- a/src/components/ThemePicker/index.vue
+++ b/src/components/ThemePicker/index.vue
@@ -65,12 +65,18 @@ export default {
   },
 
   methods: {
-    updateStyle(style, oldCluster, newCluster) {
-      let newStyle = style
+    updateStyle(style, oldCluster, newCluster) {      
+      let colorOverrides = [] // only capture color overides
       oldCluster.forEach((color, index) => {
-        newStyle = newStyle.replace(new RegExp(color, 'ig'), newCluster[index])
+        let value = newCluster[index]
+        let repl = new RegExp(`(^|})([^{]+{[^{}]+)${color}\\b([^}]*)(?=})`, 'gi')
+        let nestRepl = new RegExp(color, 'ig') // for greed matching before the 'color'
+        let v
+        while ((v = repl.exec(data))) {
+          colorOverrides.push(v[2].replace(nestRepl, value) + value + v[3] + '}') // '}' not captured in the regexp repl to reserve it as locator-boundary
+        }
       })
-      return newStyle
+      return colorOverrides.join('')
     },
 
     getCSSString(url, callback, variable) {

--- a/src/components/ThemePicker/index.vue
+++ b/src/components/ThemePicker/index.vue
@@ -66,11 +66,11 @@ export default {
 
   methods: {
     updateStyle(style, oldCluster, newCluster) {
-      let colorOverrides = [] // only capture color overides
+      const colorOverrides = [] // only capture color overides
       oldCluster.forEach((color, index) => {
-        let value = newCluster[index]
-        let repl = new RegExp(`(^|})([^{]+{[^{}]+)${color}\\b([^}]*)(?=})`, 'gi')
-        let nestRepl = new RegExp(color, 'ig') // for greed matching before the 'color'
+        const value = newCluster[index]
+        const repl = new RegExp(`(^|})([^{]+{[^{}]+)${color}\\b([^}]*)(?=})`, 'gi')
+        const nestRepl = new RegExp(color, 'ig') // for greed matching before the 'color'
         let v
         while ((v = repl.exec(style))) {
           colorOverrides.push(v[2].replace(nestRepl, value) + value + v[3] + '}') // '}' not captured in the regexp repl to reserve it as locator-boundary


### PR DESCRIPTION
 theme replacing should cut tons of irrelevant css
风格替换既然是颜色,那么应该削减大量无关的代码. 可以通过regexp
捕捉相关的,以上代码经过测试