### PR TITLE
fix(Tinymce): When content is null,set content to '' to avoid error

### DIFF
--- a/src/components/Tinymce/index.vue
+++ b/src/components/Tinymce/index.vue
@@ -52,7 +52,7 @@ export default {
       if (!this.hasChange && this.hasInit) {
         if (val === null) val = ''
         this.$nextTick(() =>
-          window.tinymce.get(this.tinymceId).setContent(val||''))
+          window.tinymce.get(this.tinymceId).setContent(val || ''))
       }
     }
   },

--- a/src/components/Tinymce/index.vue
+++ b/src/components/Tinymce/index.vue
@@ -51,7 +51,8 @@ export default {
     value(val) {
       if (!this.hasChange && this.hasInit) {
         if (val === null) val = ''
-        this.$nextTick(() => window.tinymce.get(this.tinymceId).setContent(val||''))
+        this.$nextTick(() =>
+          window.tinymce.get(this.tinymceId).setContent(val||''))
       }
     }
   },

--- a/src/components/Tinymce/index.vue
+++ b/src/components/Tinymce/index.vue
@@ -50,7 +50,6 @@ export default {
   watch: {
     value(val) {
       if (!this.hasChange && this.hasInit) {
-        if (val === null) val = ''
         this.$nextTick(() =>
           window.tinymce.get(this.tinymceId).setContent(val || ''))
       }

--- a/src/components/Tinymce/index.vue
+++ b/src/components/Tinymce/index.vue
@@ -50,6 +50,7 @@ export default {
   watch: {
     value(val) {
       if (!this.hasChange && this.hasInit) {
+        if(val === null) val = ''
         this.$nextTick(() => window.tinymce.get(this.tinymceId).setContent(val))
       }
     }

--- a/src/components/Tinymce/index.vue
+++ b/src/components/Tinymce/index.vue
@@ -51,7 +51,7 @@ export default {
     value(val) {
       if (!this.hasChange && this.hasInit) {
         if (val === null) val = ''
-        this.$nextTick(() => window.tinymce.get(this.tinymceId).setContent(val))
+        this.$nextTick(() => window.tinymce.get(this.tinymceId).setContent(val||''))
       }
     }
   },

--- a/src/components/Tinymce/index.vue
+++ b/src/components/Tinymce/index.vue
@@ -50,7 +50,7 @@ export default {
   watch: {
     value(val) {
       if (!this.hasChange && this.hasInit) {
-        if(val === null) val = ''
+        if (val === null) val = ''
         this.$nextTick(() => window.tinymce.get(this.tinymceId).setContent(val))
       }
     }


### PR DESCRIPTION
When get rich editor value(null) from backend,it will occur error
```
Error in nextTick: "TypeError: Cannot read property 'replace' of null"
```
So I set val to '' to avoid it