### PR TITLE
Support route querystring in layout TagView

### DIFF
--- a/src/store/modules/tagsView.js
+++ b/src/store/modules/tagsView.js
@@ -6,11 +6,9 @@ const tagsView = {
   mutations: {
     ADD_VISITED_VIEWS: (state, view) => {
       if (state.visitedViews.some(v => v.path === view.path)) return
-      state.visitedViews.push({
-        name: view.name,
-        path: view.path,
+      state.visitedViews.push(Object.assign({}, view, {
         title: view.meta.title || 'no-name'
-      })
+      }))
       if (!view.meta.noCache) {
         state.cachedViews.push(view.name)
       }

--- a/src/views/layout/components/TagsView.vue
+++ b/src/views/layout/components/TagsView.vue
@@ -2,7 +2,7 @@
   <div class="tags-view-container">
     <scroll-pane class='tags-view-wrapper' ref='scrollPane'>
       <router-link ref='tag' class="tags-view-item" :class="isActive(tag)?'active':''" v-for="tag in Array.from(visitedViews)"
-        :to="tag.path" :key="tag.path" @contextmenu.prevent.native="openMenu(tag,$event)">
+        :to="tag" :key="tag.path" @contextmenu.prevent.native="openMenu(tag,$event)">
         {{generateTitle(tag.title)}}
         <span class='el-icon-close' @click.prevent.stop='closeSelectedTag(tag)'></span>
       </router-link>


### PR DESCRIPTION
TagView 组件补全
在 `$store.state.tagsView.visitedViews` 中保存完整的 route 对象
使用场景：可以将 query 在 TagView 组件中保存，通过 Tag 切换路由不丢失 querystring 等