### PR TITLE
chore: use Runtime-only

### DIFF
--- a/build/webpack.base.conf.js
+++ b/build/webpack.base.conf.js
@@ -34,7 +34,6 @@ module.exports = {
   resolve: {
     extensions: ['.js', '.vue', '.json'],
     alias: {
-      'vue$': 'vue/dist/vue.esm.js',
       '@': resolve('src'),
     }
   },

--- a/src/main.js
+++ b/src/main.js
@@ -36,6 +36,6 @@ new Vue({
   router,
   store,
   i18n,
-  template: '<App/>',
+  render: h => h(App),
   components: { App }
 })

--- a/src/main.js
+++ b/src/main.js
@@ -36,6 +36,5 @@ new Vue({
   router,
   store,
   i18n,
-  render: h => h(App),
-  components: { App }
+  render: h => h(App)
 })


### PR DESCRIPTION
Detail see [Runtime-Compiler-vs-Runtime-only](https://vuejs.org/v2/guide/installation.html#Runtime-Compiler-vs-Runtime-only)