### PR TITLE
feat: 避免移动端点击 tagsView 触发关闭

### DIFF
--- a/src/store/getters.js
+++ b/src/store/getters.js
@@ -13,6 +13,7 @@ const getters = {
   setting: state => state.user.setting,
   permission_routers: state => state.permission.routers,
   addRouters: state => state.permission.addRouters,
-  errorLogs: state => state.errorLog.logs
+  errorLogs: state => state.errorLog.logs,
+  isMobile: state => state.app.device === 'mobile'
 }
 export default getters

--- a/src/views/layout/components/TagsView.vue
+++ b/src/views/layout/components/TagsView.vue
@@ -10,7 +10,7 @@
         class="tags-view-item"
         @contextmenu.prevent.native="openMenu(tag,$event)">
         {{ generateTitle(tag.title) }}
-        <span class="el-icon-close" @click.prevent.stop="closeSelectedTag(tag)"/>
+        <span v-show="!isMobile" class="el-icon-close" @click.prevent.stop="closeSelectedTag(tag)"/>
       </router-link>
     </scroll-pane>
     <ul v-show="visible" :style="{left:left+'px',top:top+'px'}" class="contextmenu">
@@ -22,6 +22,7 @@
 </template>
 
 <script>
+import { mapGetters } from 'vuex'
 import ScrollPane from '@/components/ScrollPane'
 import { generateTitle } from '@/utils/i18n'
 
@@ -36,6 +37,7 @@ export default {
     }
   },
   computed: {
+    ...mapGetters(['isMobile']),
     visitedViews() {
       return this.$store.state.tagsView.visitedViews
     }


### PR DESCRIPTION
+ 添加 ‘vuex getter isMobile’ 
+ 当 `isMobile:true` 隐藏关闭小图标
```
<span v-show="!isMobile" class="el-icon-close"@click.prevent.stop="closeSelectedTag(tag)"/>
```