### PR TITLE
switch roles will refresh the sidebar correctly

### DIFF
--- a/src/store/modules/permission.js
+++ b/src/store/modules/permission.js
@@ -7,7 +7,7 @@ import { asyncRouterMap, constantRouterMap } from '@/router'
  */
 function hasPermission(roles, route) {
   if (route.meta && route.meta.roles) {
-    return roles.some(role => route.meta.roles.indexOf(role) >= 0)
+    return roles.some(role => route.meta.roles.includes(role))
   } else {
     return true
   }
@@ -15,21 +15,42 @@ function hasPermission(roles, route) {
 
 /**
  * 递归过滤异步路由表，返回符合用户角色权限的路由表
+ * 方法优化 避免执行一次以后 对原始 aysncRouterMap 的改动
+ * @param routes asyncRouterMap
+ * @param roles
+ */
+function filterAsyncRouter(routes, roles) {
+  const res = []
+
+  routes.forEach(route => {
+    const tmp = { ...route }
+    if (tmp.children) {
+      tmp.children = filterAsyncRouter(tmp.children, roles)
+    }
+
+    hasPermission(roles, tmp) && res.push(tmp)
+  })
+
+  return res
+}
+// 原方法 执行一次后 会修改 import 进来的 asyncRouterMap 导致切换权限菜单无法重绘
+/**
+ * 递归过滤异步路由表，返回符合用户角色权限的路由表
  * @param asyncRouterMap
  * @param roles
  */
-function filterAsyncRouter(asyncRouterMap, roles) {
-  const accessedRouters = asyncRouterMap.filter(route => {
-    if (hasPermission(roles, route)) {
-      if (route.children && route.children.length) {
-        route.children = filterAsyncRouter(route.children, roles)
-      }
-      return true
-    }
-    return false
-  })
-  return accessedRouters
-}
+// function filterAsyncRouter(asyncRouterMap, roles) {
+//   const accessedRouters = asyncRouterMap.filter(route => {
+//     if (hasPermission(roles, route)) {
+//       if (route.children && route.children.length) {
+//         route.children = filterAsyncRouter(route.children, roles)
+//       }
+//       return true
+//     }
+//     return false
+//   })
+//   return accessedRouters
+// }
 
 const permission = {
   state: {
@@ -47,7 +68,7 @@ const permission = {
       return new Promise(resolve => {
         const { roles } = data
         let accessedRouters
-        if (roles.indexOf('admin') >= 0) {
+        if (roles.includes('admin')) {
           accessedRouters = asyncRouterMap
         } else {
           accessedRouters = filterAsyncRouter(asyncRouterMap, roles)

--- a/src/store/modules/permission.js
+++ b/src/store/modules/permission.js
@@ -23,11 +23,12 @@ function filterAsyncRouter(routes, roles) {
 
   routes.forEach(route => {
     const tmp = { ...route }
-    if (tmp.children) {
-      tmp.children = filterAsyncRouter(tmp.children, roles)
+    if (hasPermission(roles, tmp)) {
+      if (tmp.children) {
+        tmp.children = filterAsyncRouter(tmp.children, roles)
+      }
+      res.push(tmp)
     }
-
-    hasPermission(roles, tmp) && res.push(tmp)
   })
 
   return res

--- a/src/store/modules/permission.js
+++ b/src/store/modules/permission.js
@@ -15,7 +15,6 @@ function hasPermission(roles, route) {
 
 /**
  * 递归过滤异步路由表，返回符合用户角色权限的路由表
- * 方法优化 避免执行一次以后 对原始 aysncRouterMap 的改动
  * @param routes asyncRouterMap
  * @param roles
  */
@@ -33,24 +32,6 @@ function filterAsyncRouter(routes, roles) {
 
   return res
 }
-// 原方法 执行一次后 会修改 import 进来的 asyncRouterMap 导致切换权限菜单无法重绘
-/**
- * 递归过滤异步路由表，返回符合用户角色权限的路由表
- * @param asyncRouterMap
- * @param roles
- */
-// function filterAsyncRouter(asyncRouterMap, roles) {
-//   const accessedRouters = asyncRouterMap.filter(route => {
-//     if (hasPermission(roles, route)) {
-//       if (route.children && route.children.length) {
-//         route.children = filterAsyncRouter(route.children, roles)
-//       }
-//       return true
-//     }
-//     return false
-//   })
-//   return accessedRouters
-// }
 
 const permission = {
   state: {

--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -122,7 +122,7 @@ const user = {
     },
 
     // 动态修改权限
-    ChangeRoles({ commit }, role) {
+    ChangeRoles({ commit, dispatch }, role) {
       return new Promise(resolve => {
         commit('SET_TOKEN', role)
         setToken(role)
@@ -132,6 +132,7 @@ const user = {
           commit('SET_NAME', data.name)
           commit('SET_AVATAR', data.avatar)
           commit('SET_INTRODUCTION', data.introduction)
+          dispatch('GenerateRoutes', data) // 动态修改权限后 重绘侧边菜单
           resolve()
         })
       })


### PR DESCRIPTION
后台菜单->权限测试页->指令权限 切换角色 会正确 刷新侧边栏

> /src/store/modules/permission.js

原方法在递归筛选侧边菜单后， 会意外修改原始 asyncRouterMap 导致侧边菜单重绘不正常
已经用新方法替代修复  结果入下图

![图片](https://s1.ax1x.com/2018/09/07/iCL7f1.gif)