### PR TITLE
修复 Mock 导致请求丢失 Cookie 的问题

### DIFF
--- a/src/mock/index.js
+++ b/src/mock/index.js
@@ -4,9 +4,10 @@ import articleAPI from './article'
 import remoteSearchAPI from './remoteSearch'
 import transactionAPI from './transaction'
 
-// * 修复 Mock 情况下，设置 withCredentials = true，且未被拦截的跨域请求丢失 Cookies 的问题
+// 修复在使用 MockJS 情况下，设置 withCredentials = true，且未被拦截的跨域请求丢失 Cookies 的问题
+// https://github.com/nuysoft/Mock/issues/300
 Mock.XHR.prototype.proxy_send = Mock.XHR.prototype.send
-Mock.XHR.prototype.send = function () {
+Mock.XHR.prototype.send = function() {
   if (this.custom.xhr) {
     this.custom.xhr.withCredentials = this.withCredentials || false
   }

--- a/src/mock/index.js
+++ b/src/mock/index.js
@@ -4,6 +4,15 @@ import articleAPI from './article'
 import remoteSearchAPI from './remoteSearch'
 import transactionAPI from './transaction'
 
+// * 修复 Mock 情况下，设置 withCredentials = true，且未被拦截的跨域请求丢失 Cookies 的问题
+Mock.XHR.prototype.proxy_send = Mock.XHR.prototype.send
+Mock.XHR.prototype.send = function () {
+  if (this.custom.xhr) {
+    this.custom.xhr.withCredentials = this.withCredentials || false
+  }
+  this.proxy_send(...arguments)
+}
+
 // Mock.setup({
 //   timeout: '350-600'
 // })


### PR DESCRIPTION
修复 Mock 导致 Cookie 丢失的问题，只有在 XHR.open() 周期时，自定义的 withCredentials 会被挂载，此时检查是否是未被拦截的 xhr，并挂载自定义的 withCredentials ，无则默认为 false