### PR TITLE
修改currentTag为中间tag时查询前后tag的方式

### DIFF
--- a/src/components/ScrollPane/index.vue
+++ b/src/components/ScrollPane/index.vue
@@ -28,8 +28,6 @@ export default {
 
       let firstTag = null
       let lastTag = null
-      let prevTag = null
-      let nextTag = null
 
       // find first tag and last tag
       if (tagList.length > 0) {
@@ -37,26 +35,15 @@ export default {
         lastTag = tagList[tagList.length - 1]
       }
 
-      // find preTag and nextTag
-      for (let i = 0; i < tagList.length; i++) {
-        if (tagList[i] === currentTag) {
-          if (i === 0) {
-            nextTag = tagList[i].length > 1 && tagList[i + 1]
-          } else if (i === tagList.length - 1) {
-            prevTag = tagList[i].length > 1 && tagList[i - 1]
-          } else {
-            prevTag = tagList[i - 1]
-            nextTag = tagList[i + 1]
-          }
-          break
-        }
-      }
-
       if (firstTag === currentTag) {
         $scrollWrapper.scrollLeft = 0
       } else if (lastTag === currentTag) {
         $scrollWrapper.scrollLeft = $scrollWrapper.scrollWidth - $containerWidth
       } else {
+        // find preTag and nextTag
+        const currentIndex = tagList.findIndex(item => item === currentTag)
+        const prevTag = tagList[currentIndex - 1]
+        const nextTag = tagList[currentIndex + 1]
         // the tag's offsetLeft after of nextTag
         const afterNextTagOffsetLeft = nextTag.$el.offsetLeft + nextTag.$el.offsetWidth + tagAndTagSpacing
 


### PR DESCRIPTION
ScrollPane无用代码和冗余代码 --------moveToTarget这个方法中，我认为cuurentTag为第一个和最后一个时，不用去遍历节点找preTag和nextTag，此外，visitedViews[i].length > 1，我认为是没有意义的，我不理解为什么要这样用，为什么要去判断当前节点的length，是undifined啊，所以删除了里面的for循环