### PR TITLE
优化 parseTime

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -13,7 +13,9 @@ export function parseTime(time, cFormat) {
   } else {
     if ((typeof time === 'string') && (/^[0-9]+$/.test(time))) {
       time = parseInt(time)
-      if (time.toString().length === 10) time = time * 1000
+    }
+    if ((typeof time === 'number') && (time.toString().length === 10)) {
+      time = time * 1000
     }
     date = new Date(time)
   }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -11,7 +11,10 @@ export function parseTime(time, cFormat) {
   if (typeof time === 'object') {
     date = time
   } else {
-    if (('' + time).length === 10) time = parseInt(time) * 1000
+    if ((typeof time === 'string') && (/^[0-9]+$/.test(time))) {
+      time = parseInt(time)
+      if (time.toString().length === 10) time = time * 1000
+    }
     date = new Date(time)
   }
   const formatObj = {


### PR DESCRIPTION
修复传入的时间戳是字符串类型，不能转换时间的问题
例：parseTime("1548221490638")