### PR TITLE
feat: menus get from remote

### DIFF
--- a/src/api/menu.js
+++ b/src/api/menu.js
@@ -1,0 +1,11 @@
+import request from '@/utils/request'
+/**
+  *根据角色获得可见菜单
+  */
+export function getMenuByRole(query) {
+  return request({
+    url: '/menus/role',
+    method: 'get',
+    params: query
+  })
+}

--- a/src/mock/index.js
+++ b/src/mock/index.js
@@ -3,6 +3,7 @@ import loginAPI from './login'
 import articleAPI from './article'
 import remoteSearchAPI from './remoteSearch'
 import transactionAPI from './transaction'
+import menuAPI from './menu'
 
 // 修复在使用 MockJS 情况下，设置 withCredentials = true，且未被拦截的跨域请求丢失 Cookies 的问题
 // https://github.com/nuysoft/Mock/issues/300
@@ -22,6 +23,9 @@ Mock.XHR.prototype.send = function() {
 Mock.mock(/\/login\/login/, 'post', loginAPI.loginByUsername)
 Mock.mock(/\/login\/logout/, 'post', loginAPI.logout)
 Mock.mock(/\/user\/info\.*/, 'get', loginAPI.getUserInfo)
+
+// 角色相关
+Mock.mock(/\/menus\/role/, 'get', menuAPI.getMenuByRole)
 
 // 文章相关
 Mock.mock(/\/article\/list/, 'get', articleAPI.getList)

--- a/src/mock/menu.js
+++ b/src/mock/menu.js
@@ -1,0 +1,72 @@
+const menuData =
+[
+  {
+    'id': 1,
+    'path': '/console',
+    'redirect': 'noredirect',
+    'component': 'Layout',
+    'name': 'console',
+    'title': '系统管理',
+    'icon': 'component',
+    'parentId': -1,
+    'children': [
+      {
+        'children': [],
+        'name': 'user',
+        'component': 'console/user/index',
+        'id': 7,
+        'title': '用户管理',
+        'icon': 'user',
+        'parentId': 1,
+        'path': 'user'
+      },
+      {
+        'children': [],
+        'name': 'menu',
+        'component': 'console/menu/index',
+        'id': 8,
+        'title': '菜单管理',
+        'icon': 'documentation',
+        'parentId': 1,
+        'path': 'menu'
+      },
+      {
+        'children': [],
+        'name': 'role',
+        'component': 'console/role/index',
+        'id': 9,
+        'title': '角色管理',
+        'icon': 'documentation',
+        'parentId': 1,
+        'path': 'role'
+      },
+      {
+        'children': [],
+        'name': 'dict',
+        'component': 'console/dict/index',
+        'id': 10,
+        'title': '字典管理',
+        'icon': 'documentation',
+        'parentId': 1,
+        'path': 'dict'
+      },
+      {
+        'children': [],
+        'name': 'dept',
+        'component': 'console/dept/index',
+        'id': 11,
+        'title': '部门管理',
+        'icon': 'documentation',
+        'parentId': 1,
+        'path': 'dept'
+      }
+    ]
+  }
+
+]
+
+export default {
+  getMenuByRole: config => {
+    return menuData
+  }
+}

--- a/src/permission.js
+++ b/src/permission.js
@@ -4,7 +4,7 @@ import { Message } from 'element-ui'
 import NProgress from 'nprogress' // progress bar
 import 'nprogress/nprogress.css'// progress bar style
 import { getToken } from '@/utils/auth' // getToken from cookie
-
+import { validatenull } from '@/utils/validate'
 NProgress.configure({ showSpinner: false })// NProgress Configuration
 
 // permission judge function
@@ -27,8 +27,12 @@ router.beforeEach((to, from, next) => {
       if (store.getters.roles.length === 0) { // 判断当前用户是否已拉取完user_info信息
         store.dispatch('GetUserInfo').then(res => { // 拉取user_info
           const roles = res.data.roles // note: roles must be a array! such as: ['editor','develop']
-          store.dispatch('GenerateRoutes', { roles }).then(() => { // 根据roles权限生成可访问的路由表
-            router.addRoutes(store.getters.addRouters) // 动态添加可访问路由表
+          store.dispatch('GenerateRoutes', { roles }).then((accessedRouters) => { // 根据roles权限生成可访问的路由表
+            if (!validatenull(accessedRouters)) {
+              router.addRoutes(accessedRouters)
+            } else {
+              next({ path: '/401', replace: true, query: { noGoBack: true }})
+            } // 动态添加可访问路由表
             next({ ...to, replace: true }) // hack方法 确保addRoutes已完成 ,set the replace: true so the navigation will not leave a history record
           })
         }).catch((err) => {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -75,7 +75,16 @@ export const constantRouterMap = [
         meta: { title: 'dashboard', icon: 'dashboard', noCache: true }
       }
     ]
-  },
+  }
+]
+
+export default new Router({
+  // mode: 'history', // require service support
+  scrollBehavior: () => ({ y: 0 }),
+  routes: constantRouterMap
+})
+
+let localRoutermap = [
   {
     path: '/documentation',
     component: Layout,
@@ -101,16 +110,7 @@ export const constantRouterMap = [
         meta: { title: 'guide', icon: 'guide', noCache: true }
       }
     ]
-  }
-]
-
-export default new Router({
-  // mode: 'history', // require service support
-  scrollBehavior: () => ({ y: 0 }),
-  routes: constantRouterMap
-})
-
-export const asyncRouterMap = [
+  },
   {
     path: '/permission',
     component: Layout,
@@ -142,7 +142,6 @@ export const asyncRouterMap = [
       }
     ]
   },
-
   {
     path: '/icon',
     component: Layout,
@@ -193,7 +192,6 @@ export const asyncRouterMap = [
       }
     ]
   },
-
   {
     path: '/tab',
     component: Layout,
@@ -206,7 +204,6 @@ export const asyncRouterMap = [
       }
     ]
   },
-
   {
     path: '/error',
     component: Layout,
@@ -366,3 +363,15 @@ export const asyncRouterMap = [
 
   { path: '*', redirect: '/404', hidden: true }
 ]
+
+const routerGetType = 'local'
+
+if (routerGetType === 'server') {
+  localRoutermap = [
+    { path: '*', redirect: '/404', hidden: true }
+  ]
+}
+
+export const routerMode = routerGetType
+
+export const asyncRouterMap = localRoutermap

--- a/src/store/modules/permission.js
+++ b/src/store/modules/permission.js
@@ -1,4 +1,9 @@
-import { asyncRouterMap, constantRouterMap } from '@/router'
+import { asyncRouterMap, constantRouterMap, routerMode } from '@/router'
+
+import { validatenull } from '@/utils/validate'
+// for get menus from server
+import { getMenuByRole } from '@/api/menu'
+import Layout from '@/views/layout/Layout'
 
 /**
  * 通过meta.role判断是否与当前用户权限匹配
@@ -47,19 +52,81 @@ const permission = {
   },
   actions: {
     GenerateRoutes({ commit }, data) {
-      return new Promise(resolve => {
+      // default routerMode is local
+      if (routerMode === 'local') {
+        return new Promise(resolve => {
+          const { roles } = data
+          let accessedRouters
+          if (roles.includes('admin')) {
+            accessedRouters = asyncRouterMap
+          } else {
+            accessedRouters = filterAsyncRouter(asyncRouterMap, roles)
+          }
+          commit('SET_ROUTERS', accessedRouters)
+          // return for add to router
+          resolve(accessedRouters)
+        })
+      } else {
         const { roles } = data
-        let accessedRouters
-        if (roles.includes('admin')) {
-          accessedRouters = asyncRouterMap
-        } else {
-          accessedRouters = filterAsyncRouter(asyncRouterMap, roles)
-        }
-        commit('SET_ROUTERS', accessedRouters)
-        resolve()
-      })
+        return new Promise((resolve, reject) => {
+          getMenuByRole(roles[0]).then(response => {
+            if (!response.data) {
+              reject('GenerateRoutesFromServer failed, please try later again.')
+            }
+
+            const menus = response.data
+
+            if (menus.length === 0) {
+              reject('menus data is null')
+            }
+            const accessedRouters = buildRouter(menus)
+            // final add 404
+            accessedRouters.push({ path: '*', redirect: '/404', hidden: true })
+            // commit to stores
+            commit('SET_ROUTERS', accessedRouters)
+            // return for add to router
+            resolve(accessedRouters)
+          })
+        })
+      }
     }
   }
+}
+
+/** ************************************
+ * build Router by menu api
+ * add 20190213
+***************************************/
+function buildRouter(aMenu) {
+  const aRouter = []
+  aMenu.forEach(item => {
+    if (!validatenull(item.component)) {
+      const oRouter = {
+        meta: { 'title': '', 'icon': '' },
+        children: []
+      }
+
+      if (item.component === 'Layout') {
+        oRouter.component = Layout
+      } else {
+        oRouter.component = require('@/views/' + item.component + '.vue').default
+      }
+
+      oRouter.path = item.path
+      oRouter.name = item.name
+      oRouter.id = item.id || null
+      oRouter.redirect = item.redirect || null
+      oRouter.meta.icon = item.icon
+      oRouter.meta.title = item.title
+      oRouter.meta.noCache = item.noCache || false
+      oRouter.meta.breadcrumb = item.breadcrumb || true
+      oRouter.children = validatenull(item.children) ? [] : buildRouter(item.children)
+
+      aRouter.push(oRouter)
+    }
+  })
+
+  return aRouter
 }
 
 export default permission

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -40,3 +40,19 @@ export function validateEmail(email) {
   const re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
   return re.test(email)
 }
+
+/**
+ * validate null
+ * @param {*} val
+ */
+export function validatenull(val) {
+  if (val instanceof Array) {
+    if (val.length === 0) return true
+  } else if (val instanceof Object) {
+    if (JSON.stringify(val) === '{}') return true
+  } else {
+    if (val === 'null' || val === null || val === 'undefined' || val === undefined || val === '') return true
+    return false
+  }
+  return false
+}

--- a/src/views/console/dept/index.vue
+++ b/src/views/console/dept/index.vue
@@ -1,0 +1,9 @@
+<template>
+  <div class="app-container">
+    DEPT
+  </div>
+</template>
+
+<script>
+
+</script>

--- a/src/views/console/dict/index.vue
+++ b/src/views/console/dict/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="app-container">
+    DICT
+  </div>
+</template>

--- a/src/views/console/menu/index.vue
+++ b/src/views/console/menu/index.vue
@@ -1,0 +1,19 @@
+<template>
+  <div class="app-container">
+    this is {{ token() }} menus
+  </div>
+</template>
+
+<script>
+
+import { mapGetters } from 'vuex'
+
+export default {
+  methods: {
+    ...mapGetters([
+      'token'
+    ])
+  }
+
+}
+</script>

--- a/src/views/console/role/index.vue
+++ b/src/views/console/role/index.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="app-container">
+    ROLE
+  </div>
+</template>

--- a/src/views/console/user/index.vue
+++ b/src/views/console/user/index.vue
@@ -1,0 +1,355 @@
+<template>
+  <div class="app-container">
+    <div class="filter-container">
+      <el-input :placeholder="$t('table.title')" v-model="listQuery.title" style="width: 200px;" class="filter-item" @keyup.enter.native="handleFilter"/>
+      <el-select v-model="listQuery.importance" :placeholder="$t('table.importance')" clearable style="width: 90px" class="filter-item">
+        <el-option v-for="item in importanceOptions" :key="item" :label="item" :value="item"/>
+      </el-select>
+      <el-select v-model="listQuery.type" :placeholder="$t('table.type')" clearable class="filter-item" style="width: 130px">
+        <el-option v-for="item in calendarTypeOptions" :key="item.key" :label="item.display_name+'('+item.key+')'" :value="item.key"/>
+      </el-select>
+      <el-select v-model="listQuery.sort" style="width: 140px" class="filter-item" @change="handleFilter">
+        <el-option v-for="item in sortOptions" :key="item.key" :label="item.label" :value="item.key"/>
+      </el-select>
+      <el-button v-waves class="filter-item" type="primary" icon="el-icon-search" @click="handleFilter">{{ $t('table.search') }}</el-button>
+      <el-button class="filter-item" style="margin-left: 10px;" type="primary" icon="el-icon-edit" @click="handleCreate">{{ $t('table.add') }}</el-button>
+      <el-button v-waves :loading="downloadLoading" class="filter-item" type="primary" icon="el-icon-download" @click="handleDownload">{{ $t('table.export') }}</el-button>
+      <el-checkbox v-model="showReviewer" class="filter-item" style="margin-left:15px;" @change="tableKey=tableKey+1">{{ $t('table.reviewer') }}</el-checkbox>
+    </div>
+
+    <el-table
+      v-loading="listLoading"
+      :key="tableKey"
+      :data="list"
+      element-loading-text="给我一点时间"
+      border
+      fit
+      highlight-current-row
+      style="width: 100%">
+      <el-table-column :label="$t('table.id')" align="center" width="65">
+        <template slot-scope="scope">
+          <span>{{ scope.row.id }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column :label="$t('table.date')" width="150px" align="center">
+        <template slot-scope="scope">
+          <span>{{ scope.row.timestamp | parseTime('{y}-{m}-{d} {h}:{i}') }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column :label="$t('table.title')" min-width="150px">
+        <template slot-scope="scope">
+          <span class="link-type" @click="handleUpdate(scope.row)">{{ scope.row.title }}</span>
+          <el-tag>{{ scope.row.type | typeFilter }}</el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column :label="$t('table.author')" width="110px" align="center">
+        <template slot-scope="scope">
+          <span>{{ scope.row.author }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column v-if="showReviewer" :label="$t('table.reviewer')" width="110px" align="center">
+        <template slot-scope="scope">
+          <span style="color:red;">{{ scope.row.reviewer }}</span>
+        </template>
+      </el-table-column>
+      <el-table-column :label="$t('table.importance')" width="80px">
+        <template slot-scope="scope">
+          <svg-icon v-for="n in +scope.row.importance" :key="n" icon-class="star" class="meta-item__icon"/>
+        </template>
+      </el-table-column>
+      <el-table-column :label="$t('table.readings')" align="center" width="95">
+        <template slot-scope="scope">
+          <span v-if="scope.row.pageviews" class="link-type" @click="handleFetchPv(scope.row.pageviews)">{{ scope.row.pageviews }}</span>
+          <span v-else>0</span>
+        </template>
+      </el-table-column>
+      <el-table-column :label="$t('table.status')" class-name="status-col" width="100">
+        <template slot-scope="scope">
+          <el-tag :type="scope.row.status | statusFilter">{{ scope.row.status }}</el-tag>
+        </template>
+      </el-table-column>
+      <el-table-column :label="$t('table.actions')" align="center" width="230" class-name="small-padding fixed-width">
+        <template slot-scope="scope">
+          <el-button type="primary" size="mini" @click="handleUpdate(scope.row)">{{ $t('table.edit') }}</el-button>
+          <el-button v-if="scope.row.status!='published'" size="mini" type="success" @click="handleModifyStatus(scope.row,'published')">{{ $t('table.publish') }}
+          </el-button>
+          <el-button v-if="scope.row.status!='draft'" size="mini" @click="handleModifyStatus(scope.row,'draft')">{{ $t('table.draft') }}
+          </el-button>
+          <el-button v-if="scope.row.status!='deleted'" size="mini" type="danger" @click="handleModifyStatus(scope.row,'deleted')">{{ $t('table.delete') }}
+          </el-button>
+        </template>
+      </el-table-column>
+    </el-table>
+
+    <div class="pagination-container">
+      <el-pagination :current-page="listQuery.page" :page-sizes="[10,20,30, 50]" :page-size="listQuery.limit" :total="total" background layout="total, sizes, prev, pager, next, jumper" @size-change="handleSizeChange" @current-change="handleCurrentChange"/>
+    </div>
+
+    <el-dialog :title="textMap[dialogStatus]" :visible.sync="dialogFormVisible">
+      <el-form ref="dataForm" :rules="rules" :model="temp" label-position="left" label-width="70px" style="width: 400px; margin-left:50px;">
+        <el-form-item :label="$t('table.type')" prop="type">
+          <el-select v-model="temp.type" class="filter-item" placeholder="Please select">
+            <el-option v-for="item in calendarTypeOptions" :key="item.key" :label="item.display_name" :value="item.key"/>
+          </el-select>
+        </el-form-item>
+        <el-form-item :label="$t('table.date')" prop="timestamp">
+          <el-date-picker v-model="temp.timestamp" type="datetime" placeholder="Please pick a date"/>
+        </el-form-item>
+        <el-form-item :label="$t('table.title')" prop="title">
+          <el-input v-model="temp.title"/>
+        </el-form-item>
+        <el-form-item :label="$t('table.status')">
+          <el-select v-model="temp.status" class="filter-item" placeholder="Please select">
+            <el-option v-for="item in statusOptions" :key="item" :label="item" :value="item"/>
+          </el-select>
+        </el-form-item>
+        <el-form-item :label="$t('table.importance')">
+          <el-rate v-model="temp.importance" :colors="['#99A9BF', '#F7BA2A', '#FF9900']" :max="3" style="margin-top:8px;"/>
+        </el-form-item>
+        <el-form-item :label="$t('table.remark')">
+          <el-input :autosize="{ minRows: 2, maxRows: 4}" v-model="temp.remark" type="textarea" placeholder="Please input"/>
+        </el-form-item>
+      </el-form>
+      <div slot="footer" class="dialog-footer">
+        <el-button @click="dialogFormVisible = false">{{ $t('table.cancel') }}</el-button>
+        <el-button v-if="dialogStatus=='create'" type="primary" @click="createData">{{ $t('table.confirm') }}</el-button>
+        <el-button v-else type="primary" @click="updateData">{{ $t('table.confirm') }}</el-button>
+      </div>
+    </el-dialog>
+
+    <el-dialog :visible.sync="dialogPvVisible" title="Reading statistics">
+      <el-table :data="pvData" border fit highlight-current-row style="width: 100%">
+        <el-table-column prop="key" label="Channel"/>
+        <el-table-column prop="pv" label="Pv"/>
+      </el-table>
+      <span slot="footer" class="dialog-footer">
+        <el-button type="primary" @click="dialogPvVisible = false">{{ $t('table.confirm') }}</el-button>
+      </span>
+    </el-dialog>
+
+  </div>
+</template>
+
+<script>
+import { fetchList, fetchPv, createArticle, updateArticle } from '@/api/article'
+import waves from '@/directive/waves' // 水波纹指令
+import { parseTime } from '@/utils'
+
+const calendarTypeOptions = [
+  { key: 'CN', display_name: 'China' },
+  { key: 'US', display_name: 'USA' },
+  { key: 'JP', display_name: 'Japan' },
+  { key: 'EU', display_name: 'Eurozone' }
+]
+
+// arr to obj ,such as { CN : "China", US : "USA" }
+const calendarTypeKeyValue = calendarTypeOptions.reduce((acc, cur) => {
+  acc[cur.key] = cur.display_name
+  return acc
+}, {})
+
+export default {
+  name: 'ComplexTable',
+  directives: {
+    waves
+  },
+  filters: {
+    statusFilter(status) {
+      const statusMap = {
+        published: 'success',
+        draft: 'info',
+        deleted: 'danger'
+      }
+      return statusMap[status]
+    },
+    typeFilter(type) {
+      return calendarTypeKeyValue[type]
+    }
+  },
+  data() {
+    return {
+      tableKey: 0,
+      list: null,
+      total: null,
+      listLoading: true,
+      listQuery: {
+        page: 1,
+        limit: 20,
+        importance: undefined,
+        title: undefined,
+        type: undefined,
+        sort: '+id'
+      },
+      importanceOptions: [1, 2, 3],
+      calendarTypeOptions,
+      sortOptions: [{ label: 'ID Ascending', key: '+id' }, { label: 'ID Descending', key: '-id' }],
+      statusOptions: ['published', 'draft', 'deleted'],
+      showReviewer: false,
+      temp: {
+        id: undefined,
+        importance: 1,
+        remark: '',
+        timestamp: new Date(),
+        title: '',
+        type: '',
+        status: 'published'
+      },
+      dialogFormVisible: false,
+      dialogStatus: '',
+      textMap: {
+        update: 'Edit',
+        create: 'Create'
+      },
+      dialogPvVisible: false,
+      pvData: [],
+      rules: {
+        type: [{ required: true, message: 'type is required', trigger: 'change' }],
+        timestamp: [{ type: 'date', required: true, message: 'timestamp is required', trigger: 'change' }],
+        title: [{ required: true, message: 'title is required', trigger: 'blur' }]
+      },
+      downloadLoading: false
+    }
+  },
+  created() {
+    this.getList()
+  },
+  methods: {
+    getList() {
+      this.listLoading = true
+      fetchList(this.listQuery).then(response => {
+        this.list = response.data.items
+        this.total = response.data.total
+        this.listLoading = false
+      })
+    },
+    handleFilter() {
+      this.listQuery.page = 1
+      this.getList()
+    },
+    handleSizeChange(val) {
+      this.listQuery.limit = val
+      this.getList()
+    },
+    handleCurrentChange(val) {
+      this.listQuery.page = val
+      this.getList()
+    },
+    handleModifyStatus(row, status) {
+      this.$message({
+        message: '操作成功',
+        type: 'success'
+      })
+      row.status = status
+    },
+    resetTemp() {
+      this.temp = {
+        id: undefined,
+        importance: 1,
+        remark: '',
+        timestamp: new Date(),
+        title: '',
+        status: 'published',
+        type: ''
+      }
+    },
+    handleCreate() {
+      this.resetTemp()
+      this.dialogStatus = 'create'
+      this.dialogFormVisible = true
+      this.$nextTick(() => {
+        this.$refs['dataForm'].clearValidate()
+      })
+    },
+    createData() {
+      this.$refs['dataForm'].validate((valid) => {
+        if (valid) {
+          this.temp.id = parseInt(Math.random() * 100) + 1024 // mock a id
+          this.temp.author = 'vue-element-admin'
+          createArticle(this.temp).then(() => {
+            this.list.unshift(this.temp)
+            this.dialogFormVisible = false
+            this.$notify({
+              title: '成功',
+              message: '创建成功',
+              type: 'success',
+              duration: 2000
+            })
+          })
+        }
+      })
+    },
+    handleUpdate(row) {
+      this.temp = Object.assign({}, row) // copy obj
+      this.temp.timestamp = new Date(this.temp.timestamp)
+      this.dialogStatus = 'update'
+      this.dialogFormVisible = true
+      this.$nextTick(() => {
+        this.$refs['dataForm'].clearValidate()
+      })
+    },
+    updateData() {
+      this.$refs['dataForm'].validate((valid) => {
+        if (valid) {
+          const tempData = Object.assign({}, this.temp)
+          tempData.timestamp = +new Date(tempData.timestamp) // change Thu Nov 30 2017 16:41:05 GMT+0800 (CST) to 1512031311464
+          updateArticle(tempData).then(() => {
+            for (const v of this.list) {
+              if (v.id === this.temp.id) {
+                const index = this.list.indexOf(v)
+                this.list.splice(index, 1, this.temp)
+                break
+              }
+            }
+            this.dialogFormVisible = false
+            this.$notify({
+              title: '成功',
+              message: '更新成功',
+              type: 'success',
+              duration: 2000
+            })
+          })
+        }
+      })
+    },
+    handleDelete(row) {
+      this.$notify({
+        title: '成功',
+        message: '删除成功',
+        type: 'success',
+        duration: 2000
+      })
+      const index = this.list.indexOf(row)
+      this.list.splice(index, 1)
+    },
+    handleFetchPv(pv) {
+      fetchPv(pv).then(response => {
+        this.pvData = response.data.pvData
+        this.dialogPvVisible = true
+      })
+    },
+    handleDownload() {
+      this.downloadLoading = true
+      import('@/vendor/Export2Excel').then(excel => {
+        const tHeader = ['timestamp', 'title', 'type', 'importance', 'status']
+        const filterVal = ['timestamp', 'title', 'type', 'importance', 'status']
+        const data = this.formatJson(filterVal, this.list)
+        excel.export_json_to_excel({
+          header: tHeader,
+          data,
+          filename: 'table-list'
+        })
+        this.downloadLoading = false
+      })
+    },
+    formatJson(filterVal, jsonData) {
+      return jsonData.map(v => filterVal.map(j => {
+        if (j === 'timestamp') {
+          return parseTime(v[j])
+        } else {
+          return v[j]
+        }
+      }))
+    }
+  }
+}
+</script>


### PR DESCRIPTION
重要影响文件说明：

router/index.js  
---
    通过 routerGetType 来控制menu获取方式。默认为local，即原始本地方式。
    如果为server，则从api获取。 

src/permission.js
---
    GenerateRoutes方法直接返回出accessedRouters写入router，而不是从store内获得。
    为了一个方法可以重用，因为从server获得是异步。

store/modules/permission.js    
---
     GenerateRoutes 方法通过 routerGetType 来判断如何生成。
    如果local，原流程不变。如果为server，则动态从后端获得数据生成router。 

views  console 文件夹
---
    新增了 console文件夹，空文件，仅仅用于演示，对应mock内的菜单

src/mock/menu.js
---
演示的后端返回json数据