### PR TITLE
#1649 404 when refresh dashboard

### DIFF
--- a/src/views/layout/components/TagsView.vue
+++ b/src/views/layout/components/TagsView.vue
@@ -76,6 +76,7 @@ export default {
       routes.forEach(route => {
         if (route.meta && route.meta.affix) {
           tags.push({
+            fullPath: path.resolve(basePath, route.path),
             path: path.resolve(basePath, route.path),
             name: route.name,
             meta: { ...route.meta }


### PR DESCRIPTION
refresh 时会使用fullpath进行路由跳转，但是initTags没有对fullpath赋值，导致refresh dashboard 失败