### PR TITLE
Update index.js

### DIFF
--- a/src/mock/index.js
+++ b/src/mock/index.js
@@ -11,8 +11,7 @@ Mock.XHR.prototype.proxy_send = Mock.XHR.prototype.send
 Mock.XHR.prototype.send = function() {
   if (this.custom.xhr) {
     this.custom.xhr.withCredentials = this.withCredentials || false
-    // 确保 responseType 不会丢失
-    this.custom.xhr['responseType'] = this['responseType']
+    this.custom.xhr.responseType = this.responseType
   }
   this.proxy_send(...arguments)
 }

--- a/src/mock/index.js
+++ b/src/mock/index.js
@@ -11,6 +11,8 @@ Mock.XHR.prototype.proxy_send = Mock.XHR.prototype.send
 Mock.XHR.prototype.send = function() {
   if (this.custom.xhr) {
     this.custom.xhr.withCredentials = this.withCredentials || false
+    // 确保 responseType 不会丢失
+    this.custom.xhr['responseType'] = this['responseType']
   }
   this.proxy_send(...arguments)
 }


### PR DESCRIPTION
@PanJiaChen 

确保不会responseType丢失

#1778 相关, 

在不转到4.0的情况下，修复`mockjs`调用原生XHR时，`responseType`会丢失的问题