### PR TITLE
（创建文章页面）模糊搜索下拉框，在输入框按下回车，选择第一个匹配项

### DIFF
--- a/src/views/example/components/ArticleDetail.vue
+++ b/src/views/example/components/ArticleDetail.vue
@@ -28,7 +28,7 @@
               <el-row>
                 <el-col :span="8">
                   <el-form-item label-width="45px" label="作者:" class="postInfo-container-item">
-                    <el-select v-model="postForm.author" :remote-method="getRemoteUserList" filterable remote placeholder="搜索用户">
+                    <el-select v-model="postForm.author" :remote-method="getRemoteUserList" filterable default-first-option remote placeholder="搜索用户">
                       <el-option v-for="(item,index) in userListOptions" :key="item+index" :label="item" :value="item" />
                     </el-select>
                   </el-form-item>


### PR DESCRIPTION
其实这个属性还是看作者写菜单模糊搜索下拉框时候发现的，觉得体验非常棒。虽然文章模块这里只是一个示例，但是我觉得还是加上比较好。