### PR TITLE
revise the breadcrumb navigation of permission and zip

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -118,8 +118,9 @@ export const asyncRoutes = [
   {
     path: '/permission',
     component: Layout,
-    redirect: '/permission/index',
+    redirect: '/permission/page',
     alwaysShow: true, // will always show the root menu
+    name: 'permission',
     meta: {
       title: 'permission',
       icon: 'lock',
@@ -301,6 +302,7 @@ export const asyncRoutes = [
     component: Layout,
     redirect: '/zip/download',
     alwaysShow: true,
+    name: 'zip',
     meta: { title: 'zip', icon: 'zip' },
     children: [
       {

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -120,7 +120,7 @@ export const asyncRoutes = [
     component: Layout,
     redirect: '/permission/page',
     alwaysShow: true, // will always show the root menu
-    name: 'permission',
+    name: 'Permission',
     meta: {
       title: 'permission',
       icon: 'lock',
@@ -302,7 +302,7 @@ export const asyncRoutes = [
     component: Layout,
     redirect: '/zip/download',
     alwaysShow: true,
-    name: 'zip',
+    name: 'Zip',
     meta: { title: 'zip', icon: 'zip' },
     children: [
       {


### PR DESCRIPTION
权限测试页面中，面包屑导航如“首页/页面权限”展示为“首页/权限测试页/页面权限”，Zip页面对应面包屑导航亦同。