### PR TITLE
perf[store]: add support to sub-modules

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -5,13 +5,14 @@ import getters from './getters'
 Vue.use(Vuex)
 
 // https://webpack.js.org/guides/dependency-management/#requirecontext
-const modulesFiles = require.context('./modules', false, /\.js$/)
+const modulesFiles = require.context('./modules', true, /\.js$/)
 
 // you do not need `import app from './modules/app'`
 // it will auto require all vuex module from modules file
 const modules = modulesFiles.keys().reduce((modules, modulePath) => {
   // set './app.js' => 'app'
-  const moduleName = modulePath.replace(/^\.\/(.*)\.\w+$/, '$1')
+  var moduleName = modulePath.replace(/^\.\/(.*)\.\w+$/, '$1')
+  moduleName = moduleName.substring(moduleName.indexOf('/') + 1)
   const value = modulesFiles(modulePath)
   modules[moduleName] = value.default
   return modules

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -11,8 +11,7 @@ const modulesFiles = require.context('./modules', true, /\.js$/)
 // it will auto require all vuex module from modules file
 const modules = modulesFiles.keys().reduce((modules, modulePath) => {
   // set './app.js' => 'app'
-  var moduleName = modulePath.replace(/^\.\/(.*)\.\w+$/, '$1')
-  moduleName = moduleName.substring(moduleName.indexOf('/') + 1)
+  const moduleName = modulePath.replace(/^\.\/(.*)\.\w+$/, '$1')
   const value = modulesFiles(modulePath)
   modules[moduleName] = value.default
   return modules


### PR DESCRIPTION
Hi guy, thanks for it great app.

I need load custom store with a sub-module like is showed on image:
![Screenshot_20190509_122950](https://user-images.githubusercontent.com/2333092/57470293-778d1780-7256-11e9-80a0-7a5ae7709bd8.png)

This change allows add a sub-folder to store/modules and add all stores of sub-folder to global store

Please take a time for review it, I use this source code just now and worked

Best Regard