### PR TITLE
添加“vscode对alias全局变量的跳转”配置文件

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{ 
+  "compilerOptions": {
+    "baseUrl": "./",
+    "paths": {
+        "@/*": ["src/*"]
+    }
+  },
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
import getPageTitle from '@/utils/get-page-title'
配置此“配置文件”，vscode中可实现对上述引用文件方式，Ctrl+鼠标左键的跳转。