### PR TITLE
修改parseTime函数，优化顶部标签缓存数组的删除元素函数

### DIFF
--- a/src/store/modules/tagsView.js
+++ b/src/store/modules/tagsView.js
@@ -28,13 +28,8 @@ const mutations = {
     }
   },
   DEL_CACHED_VIEW: (state, view) => {
-    for (const i of state.cachedViews) {
-      if (i === view.name) {
-        const index = state.cachedViews.indexOf(i)
-        state.cachedViews.splice(index, 1)
-        break
-      }
-    }
+    const index = state.cachedViews.indexOf(view.name)
+    index > -1 && state.cachedViews.splice(index, 1)
   },
 
   DEL_OTHERS_VISITED_VIEWS: (state, view) => {
@@ -43,13 +38,8 @@ const mutations = {
     })
   },
   DEL_OTHERS_CACHED_VIEWS: (state, view) => {
-    for (const i of state.cachedViews) {
-      if (i === view.name) {
-        const index = state.cachedViews.indexOf(i)
-        state.cachedViews = state.cachedViews.slice(index, index + 1)
-        break
-      }
-    }
+    const index = state.cachedViews.indexOf(view.name)
+    index > -1 && (state.cachedViews = state.cachedViews.slice(index, index + 1))
   },
 
   DEL_ALL_VISITED_VIEWS: state => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,7 +6,7 @@
  * Parse the time to string
  * @param {(Object|string|number)} time
  * @param {string} cFormat
- * @returns {string}
+ * @returns {string | null}
  */
 export function parseTime(time, cFormat) {
   if (arguments.length === 0) {
@@ -34,14 +34,11 @@ export function parseTime(time, cFormat) {
     s: date.getSeconds(),
     a: date.getDay()
   }
-  const time_str = format.replace(/{(y|m|d|h|i|s|a)+}/g, (result, key) => {
-    let value = formatObj[key]
+  const time_str = format.replace(/{([ymdhisa])+}/g, (result, key) => {
+    const value = formatObj[key]
     // Note: getDay() returns 0 on Sunday
     if (key === 'a') { return ['日', '一', '二', '三', '四', '五', '六'][value ] }
-    if (result.length > 0 && value < 10) {
-      value = '0' + value
-    }
-    return value || 0
+    return value.toString().padStart(2, '0')
   })
   return time_str
 }


### PR DESCRIPTION
### /src/utils/index.js中parseTime函数：
修改：返回类型为string | null
优化：正则匹配条件，最后结果位数不足时补零的方式