### PR TITLE
fix[logout]: empty tagsview when logout

### DIFF
--- a/src/store/modules/user.js
+++ b/src/store/modules/user.js
@@ -73,13 +73,18 @@ const actions = {
   },
 
   // user logout
-  logout({ commit, state }) {
+  logout({ commit, state, dispatch }) {
     return new Promise((resolve, reject) => {
       logout(state.token).then(() => {
         commit('SET_TOKEN', '')
         commit('SET_ROLES', [])
         removeToken()
         resetRouter()
+
+        // reset visited views and cached views
+        // to fixed https://github.com/PanJiaChen/vue-element-admin/issues/2485
+        dispatch('tagsView/delAllViews', null, { root: true })
+
         resolve()
       }).catch(error => {
         reject(error)


### PR DESCRIPTION
To fixed https://github.com/PanJiaChen/vue-element-admin/issues/2485