### PR TITLE
SVG 2删除了对xlink命名空间的需要，所以不xlink:href应该使用href。

### DIFF
--- a/src/components/SvgIcon/index.vue
+++ b/src/components/SvgIcon/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="isExternal" :style="styleExternalIcon" class="svg-external-icon svg-icon" v-on="$listeners" />
   <svg v-else :class="svgClass" aria-hidden="true" v-on="$listeners">
-    <use :xlink:href="iconName" />
+    <use :href="iconName" />
   </svg>
 </template>
 


### PR DESCRIPTION
https://cloud.tencent.com/developer/section/1424047