### PR TITLE
fix[TagsView]: fixed CachedView bug (PanJiaChen#406)

### DIFF
--- a/src/store/modules/tagsView.js
+++ b/src/store/modules/tagsView.js
@@ -15,7 +15,12 @@ const mutations = {
   ADD_CACHED_VIEW: (state, view) => {
     if (state.cachedViews.includes(view.name)) return
     if (!view.meta.noCache) {
-      state.cachedViews.push(view.name)
+      for (const matchedView of view.matched) {
+        const { name } = matchedView.components.default
+        if (name && state.cachedViews.indexOf(name) === -1) {
+          state.cachedViews.push(name)
+        }
+      }
     }
   },
 


### PR DESCRIPTION
自动缓存父级组件
路由的name属性不再需要和组件名相同