### PR TITLE
fix[Logout]: click blank area of ​​dropDown able to logout

### DIFF
--- a/src/layout/components/Navbar.vue
+++ b/src/layout/components/Navbar.vue
@@ -36,8 +36,8 @@
           <a target="_blank" href="https://panjiachen.github.io/vue-element-admin-site/#/">
             <el-dropdown-item>Docs</el-dropdown-item>
           </a>
-          <el-dropdown-item divided>
-            <span style="display:block;" @click="logout">Log Out</span>
+          <el-dropdown-item divided @click.native="logout">
+            <span style="display:block;">Log Out</span>
           </el-dropdown-item>
         </el-dropdown-menu>
       </el-dropdown>


### PR DESCRIPTION
原先只能点击文字退出，点击下拉框文字旁边会关闭下拉框并没有执行退出动作