### PR TITLE
perf[Menu]: remove unused menu-wrapper

### DIFF
--- a/src/layout/components/Sidebar/SidebarItem.vue
+++ b/src/layout/components/Sidebar/SidebarItem.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!item.hidden" class="menu-wrapper">
+  <div v-if="!item.hidden">
     <template v-if="hasOneShowingChild(item.children,item) && (!onlyOneChild.children||onlyOneChild.noShowingChildren)&&!item.alwaysShow">
       <app-link v-if="onlyOneChild.meta" :to="resolvePath(onlyOneChild.path)">
         <el-menu-item :index="resolvePath(onlyOneChild.path)" :class="{'submenu-title-noDropdown':!isNest}">


### PR DESCRIPTION
The class `menu-wrapper` isn't defined anywhere in the codebase and I think it is appropriate to remove it.

<img width="1662" alt="Screen Shot 2020-01-02 at 10 45 43 AM" src="https://user-images.githubusercontent.com/20016835/71685555-837d9a80-2d4d-11ea-96f5-6c232b4a5807.png">
