### PR TITLE
fix: fixed redirect path regex

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -45,7 +45,7 @@ export const constantRoutes = [
     hidden: true,
     children: [
       {
-        path: '/redirect/:path*',
+        path: '/redirect/:path(.*)',
         component: () => import('@/views/redirect/index')
       }
     ]


### PR DESCRIPTION
稍微解释一下，vue-router 添加子路由的时候可以添加 path 为空的路由，例如

```
{
  path: '/user',
  children: [
    { path: '', name: 'UserList' },
    { path: ':id', name: 'UserDetail' }
  ]
}
```

当路由跳转到 UserList 时候，页面路径为 /user/
而跳转到 UserDetail 时候，页面路径为 /user/35
二者的区别在于最后少了一个 /

目前的 redirect 页面这种正则匹配会导致，对于 UserList 这种路由，刷新的时候会重定向到 /user，少了一个 / 

因此我稍微修改了一下，可以修复这个问题
