### PR TITLE
perf[Mock]: set responseFake to mock-server.js

### DIFF
--- a/mock/index.js
+++ b/mock/index.js
@@ -54,18 +54,4 @@ export function mockXHR() {
   }
 }
 
-// for mock server
-const responseFake = (url, type, respond) => {
-  return {
-    url: new RegExp(`${process.env.VUE_APP_BASE_API}${url}`),
-    type: type || 'get',
-    response(req, res) {
-      console.log('request invoke:' + req.path)
-      res.json(Mock.mock(respond instanceof Function ? respond(req, res) : respond))
-    }
-  }
-}
-
-export default mocks.map(route => {
-  return responseFake(route.url, route.type, route.response)
-})
+export default mocks

--- a/mock/mock-server.js
+++ b/mock/mock-server.js
@@ -2,22 +2,10 @@ const chokidar = require('chokidar')
 const bodyParser = require('body-parser')
 const chalk = require('chalk')
 const path = require('path')
+const Mock = require('mockjs')
 
 const mockDir = path.join(process.cwd(), 'mock')
 
-const Mock = require('mockjs')
-
-/**
- * 修订说明：把mock文件夹下面的文件功能进行梳理
- *
- * 1. /mock/index.js输出mockXHR()函数，使用改写
- * XMLHttpRequest对象的方式，在浏览器中拦截请求，返回响应
- *
- * 2. /mock/mock-server.js引用/mock/index.js中导出的
- * mocks数据（未经responseFake转换），自行加工后作为
- * devServer启动的express应用的路由，从而实现真正的后台
- * api服务
- */
 function registerRoutes(app) {
   let mockLastIndex
   const { default: mocks } = require('./index.js')
@@ -54,6 +42,7 @@ const responseFake = (url, type, respond) => {
     }
   }
 }
+
 module.exports = app => {
   // es6 polyfill
   require('@babel/register')


### PR DESCRIPTION
我觉得原来的功能就挺好的，mock的数据始终是用来做前端开发的。
用代理的方式，把dev-api改写到mock仿真的数据思路就很好。
其中登录405，其实都是POST请求，代理转换出现问题，就是
http-proxy-middleware的锅，我已经解决。

如果楼主同意，我可以在原来的基础上修改代码并pull request。
并提供便捷的配置方式。

主要思路（目前我自己的代码已经实现）
1. 在.env.development文件中增加环境变量配置项，用来切换mock和mock-server
（为什么在这里面配置，因为这里面配置项前端后端都可用）
2. 根据.env.development中的相关配置项，在vue.config.js的devServer.before中启动
mock-server并
3. 在main.js中根据.env.development的相关配置项，启动浏览器拦截的mock