### PR TITLE
修复优化更新后的checkCapslock存在的问题，需同步更新其他相关分支

### DIFF
--- a/src/views/login/index.vue
+++ b/src/views/login/index.vue
@@ -138,9 +138,15 @@ export default {
     // window.removeEventListener('storage', this.afterQRScan)
   },
   methods: {
-    checkCapslock(e) {
-      const { key } = e
-      this.capsTooltip = key && key.length === 1 && (key >= 'A' && key <= 'Z')
+    checkCapslock({ shiftKey, key }) {
+      if (key && key.length === 1) {
+        if (shiftKey && (key >= 'a' && key <= 'z') || !shiftKey && (key >= 'A' && key <= 'Z')) {
+          this.capsTooltip = true
+        } else {
+          this.capsTooltip = false
+        }
+      }
+      key === 'CapsLock' && this.capsTooltip === true && (this.capsTooltip = false)
     },
     showPwd() {
       if (this.passwordType === 'password') {


### PR DESCRIPTION
之前优化更新后存在的问题
1. 当大写锁定  shift 按住输入小写的时候并不能正常提示 大写被锁定
1. 当没有大写锁定  shift 按住输入小写的时候会异常提示 大写被锁定
2. 当提示大写被锁定后并不会只因为 按了 capslock 而关闭 大写被锁定的提示，alt 、ctrl、shift都可以