### PR TITLE
fix:fixed parseTime bug in ie and safari

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -17,11 +17,17 @@ export function parseTime(time, cFormat) {
   if (typeof time === 'object') {
     date = time
   } else {
-    if ((typeof time === 'string') && (/^[0-9]+$/.test(time))) {
-      time = parseInt(time)
-    } else if (typeof time === 'string') {
-      time = time.replace(new RegExp(/-/gm), '/');
+    if ((typeof time === 'string')) {
+      if ((/^[0-9]+$/.test(time))) {
+        // support "1548221490638"
+        time = parseInt(time)
+      } else {
+        // support safari
+        // https://stackoverflow.com/questions/4310953/invalid-date-in-safari
+        time = time.replace(new RegExp(/-/gm), '/')
+      }
     }
+
     if ((typeof time === 'number') && (time.toString().length === 10)) {
       time = time * 1000
     }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -19,6 +19,8 @@ export function parseTime(time, cFormat) {
   } else {
     if ((typeof time === 'string') && (/^[0-9]+$/.test(time))) {
       time = parseInt(time)
+    } else if (typeof time === 'string') {
+      time = time.replace(new RegExp(/-/gm), '/');
     }
     if ((typeof time === 'number') && (time.toString().length === 10)) {
       time = time * 1000

--- a/tests/unit/utils/parseTime.spec.js
+++ b/tests/unit/utils/parseTime.spec.js
@@ -4,6 +4,11 @@ describe('Utils:parseTime', () => {
   it('timestamp', () => {
     expect(parseTime(d)).toBe('2018-07-13 17:54:01')
   })
+
+  it('timestamp string', () => {
+    expect(parseTime((d + ''))).toBe('2018-07-13 17:54:01')
+  })
+
   it('ten digits timestamp', () => {
     expect(parseTime((d / 1000).toFixed(0))).toBe('2018-07-13 17:54:01')
   })


### PR DESCRIPTION
"2020-03-20"  这种时间格式在谷歌浏览器和高版本的火狐浏览器中是没有问题的，但是在ie浏览器和safari浏览器中会提示Invalid Date。这个问题直接导致ie与safari浏览器中不能正常处理时间问题。
在转换前换成"2020/03/20" 这样的格式。