### PR TITLE
fix[utils]: param2Obj bug when url params includes ==

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -162,19 +162,21 @@ export function param(json) {
  * @returns {Object}
  */
 export function param2Obj(url) {
-  const search = url.split('?')[1]
-  if (!search) {
-    return {}
-  }
-  return JSON.parse(
-    '{"' +
-      decodeURIComponent(search)
-        .replace(/"/g, '\\"')
-        .replace(/&/g, '","')
-        .replace(/=/g, '":"')
-        .replace(/\+/g, ' ') +
-      '"}'
-  )
+    const search = decodeURIComponent(url.split('?')[1]).replace(/\+/g, ' ')
+    if (!search) {
+        return {}
+    }
+    const obj = {}
+    const searchArr = search.split('&')
+    searchArr.forEach(v => {
+        const index = v.indexOf('=')
+        if (index !== -1) {
+            const name = v.substring(0, index)
+            const val = v.substring(index + 1, v.length)
+            obj[name] = val
+        }
+    })
+    return obj
 }
 
 /**

--- a/tests/unit/utils/param2Obj.spec.js
+++ b/tests/unit/utils/param2Obj.spec.js
@@ -1,13 +1,14 @@
 import { param2Obj } from '@/utils/index.js'
 describe('Utils:param2Obj', () => {
-  const url = 'https://github.com/PanJiaChen/vue-element-admin?name=bill&age=29&sex=1&field=dGVzdA=='
+  const url = 'https://github.com/PanJiaChen/vue-element-admin?name=bill&age=29&sex=1&field=dGVzdA==&key=%E6%B5%8B%E8%AF%95'
 
   it('param2Obj test', () => {
     expect(param2Obj(url)).toEqual({
       name: 'bill',
       age: '29',
       sex: '1',
-      field: window.btoa('test')
+      field: window.btoa('test'),
+      key: '测试'
     })
   })
 })

--- a/tests/unit/utils/param2Obj.spec.js
+++ b/tests/unit/utils/param2Obj.spec.js
@@ -1,0 +1,13 @@
+import { param2Obj } from '@/utils/index.js'
+describe('Utils:param2Obj', () => {
+  const url = 'https://github.com/PanJiaChen/vue-element-admin?name=bill&age=29&sex=1&field=dGVzdA=='
+
+  it('param2Obj test', () => {
+    expect(param2Obj(url)).toEqual({
+      name: 'bill',
+      age: '29',
+      sex: '1',
+      field: window.btoa('test')
+    })
+  })
+})


### PR DESCRIPTION
重写 param2Obj 避免 get 入参值存在 ‘=’ ,微信分享链接url可能自带含有 ‘=’ ‘==’的入参，导致原 param2Obj 解析出现问题