### PR TITLE
fix[css]: min btn width

### DIFF
--- a/src/styles/element-ui.scss
+++ b/src/styles/element-ui.scss
@@ -31,7 +31,7 @@
 .fixed-width {
   .el-button--mini {
     padding: 7px 10px;
-    width: 60px;
+    min-width: 60px;
   }
 }
 


### PR DESCRIPTION
当四个汉字时，`size="mini" ` 左右padding不一致