### PR TITLE
mock-server问题

### DIFF
--- a/mock/article.js
+++ b/mock/article.js
@@ -1,4 +1,4 @@
-import Mock from 'mockjs'
+const Mock = require('mockjs')
 
 const List = []
 const count = 100
@@ -27,7 +27,7 @@ for (let i = 0; i < count; i++) {
   }))
 }
 
-export default [
+exports.default = [
   {
     url: '/vue-element-admin/article/list',
     type: 'get',
@@ -113,4 +113,3 @@ export default [
     }
   }
 ]
-

--- a/mock/index.js
+++ b/mock/index.js
@@ -1,22 +1,17 @@
-import Mock from 'mockjs'
-import { param2Obj } from '../src/utils'
+const Mock = require('mockjs')
 
-import user from './user'
-import role from './role'
-import article from './article'
-import search from './remote-search'
+const user = require('./user')
+const role = require('./role')
+const article = require('./article')
+const search = require('./remote-search')
 
-const mocks = [
-  ...user,
-  ...role,
-  ...article,
-  ...search
-]
+const mocks = [].concat(user.default, role.default, article.default, search.default)
 
 // for front mock
 // please use it cautiously, it will redefine XMLHttpRequest,
 // which will cause many of your third-party libraries to be invalidated(like progress event).
-export function mockXHR() {
+
+exports.mockXHR = function mockXHR() {
   // mock patch
   // https://github.com/nuysoft/Mock/issues/300
   Mock.XHR.prototype.proxy_send = Mock.XHR.prototype.send
@@ -54,4 +49,20 @@ export function mockXHR() {
   }
 }
 
-export default mocks
+function param2Obj(url) {
+  const search = url.split('?')[1]
+  if (!search) {
+    return {}
+  }
+  return JSON.parse(
+    '{"' +
+      decodeURIComponent(search)
+        .replace(/"/g, '\\"')
+        .replace(/&/g, '","')
+        .replace(/=/g, '":"')
+        .replace(/\+/g, ' ') +
+      '"}'
+  )
+}
+
+exports.default = mocks

--- a/mock/mock-server.js
+++ b/mock/mock-server.js
@@ -44,9 +44,6 @@ const responseFake = (url, type, respond) => {
 }
 
 module.exports = app => {
-  // es6 polyfill
-  require('@babel/register')
-
   // parse app.body
   // https://expressjs.com/en/4x/api.html#req.body
   app.use(bodyParser.json())

--- a/mock/remote-search.js
+++ b/mock/remote-search.js
@@ -1,4 +1,4 @@
-import Mock from 'mockjs'
+const Mock = require('mockjs')
 
 const NameList = []
 const count = 100
@@ -10,7 +10,7 @@ for (let i = 0; i < count; i++) {
 }
 NameList.push({ name: 'mock-Pan' })
 
-export default [
+exports.default = [
   // username search
   {
     url: '/vue-element-admin/search/user',

--- a/mock/role/index.js
+++ b/mock/role/index.js
@@ -1,8 +1,7 @@
-import Mock from 'mockjs'
-import { deepClone } from '../../src/utils/index.js'
-import { asyncRoutes, constantRoutes } from './routes.js'
+const Mock = require('mockjs')
+const { asyncRoutes, constantRoutes } = require('./routes.js')
 
-const routes = deepClone([...constantRoutes, ...asyncRoutes])
+const routes = [].concat(constantRoutes, asyncRoutes)
 
 const roles = [
   {
@@ -35,7 +34,7 @@ const roles = [
   }
 ]
 
-export default [
+exports.default = [
   // mock get all routes form server
   {
     url: '/vue-element-admin/routes',

--- a/mock/role/routes.js
+++ b/mock/role/routes.js
@@ -1,6 +1,6 @@
 // Just a mock data
 
-export const constantRoutes = [
+const constantRoutes = [
   {
     path: '/redirect',
     component: 'layout/Layout',
@@ -72,7 +72,7 @@ export const constantRoutes = [
   }
 ]
 
-export const asyncRoutes = [
+const asyncRoutes = [
   {
     path: '/permission',
     component: 'layout/Layout',
@@ -523,3 +523,6 @@ export const asyncRoutes = [
 
   { path: '*', redirect: '/404', hidden: true }
 ]
+
+exports.constantRoutes = constantRoutes;
+exports.asyncRoutes = asyncRoutes;

--- a/mock/user.js
+++ b/mock/user.js
@@ -23,7 +23,7 @@ const users = {
   }
 }
 
-export default [
+exports.default = [
   // user login
   {
     url: '/vue-element-admin/user/login',

--- a/package.json
+++ b/package.json
@@ -72,15 +72,12 @@
     "xlsx": "0.14.1"
   },
   "devDependencies": {
-    "@babel/core": "7.0.0",
-    "@babel/register": "7.0.0",
     "@vue/cli-plugin-babel": "3.5.3",
     "@vue/cli-plugin-eslint": "^3.9.1",
     "@vue/cli-plugin-unit-jest": "3.5.3",
     "@vue/cli-service": "3.5.3",
     "@vue/test-utils": "1.0.0-beta.29",
     "autoprefixer": "^9.5.1",
-    "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "10.0.1",
     "babel-jest": "23.6.0",
     "chalk": "2.4.2",


### PR DESCRIPTION
原因：1.我在另外的项目使用"@vue/cli-plugin-babel": "^4.3.1"时，copy mock-server相关文件，
发现并不支持，是因为core-js@2.x不再维护3.x丢失相关依赖的问题，而nodejs正式版暂不支持es6

方案：1.增加更多的依赖解决core-js问题，2.减少依赖使用es5

结果：mock相关文件es6语法改为es5，并解决以后其它依赖升级问题

删除role/routes.js中import { deepClone } from '../../src/utils/index.js
简单深拷贝方法（这里使用深拷贝的目的不太理解，应该是非必须吧？）

升级依赖："mockjs": "^1.1.0",

删除依赖：
"@babel/core": "7.0.0",
"@babel/register": "7.0.0",
"babel-core": "7.0.0-bridge.0",

可支持依赖：https://github.com/mengbaiai/vue-h5-template/blob/vue-h5-template/package.json

注：方便其它项目复用 mock-server，并可在F12-Network检查模拟请求