### PR TITLE
修复在非选中状态的tagsview右键关闭全部的bug

### DIFF
--- a/src/layout/components/TagsView/index.vue
+++ b/src/layout/components/TagsView/index.vue
@@ -149,7 +149,7 @@ export default {
     },
     closeAllTags(view) {
       this.$store.dispatch('tagsView/delAllViews').then(({ visitedViews }) => {
-        if (this.affixTags.some(tag => tag.path === view.path)) {
+        if (this.affixTags.some(tag => tag.path === this.$route.path)) {
           return
         }
         this.toLastView(visitedViews, view)


### PR DESCRIPTION
在非选中状态的tagsview右键关闭全部会出现不能关闭当前路由下的页面，但是tagsviews中无此标签
如果去除 `if (this.affixTags.some(tag => tag.path === this.$route.path)) {
          return
        }` 判断则会导致如果当前页是affix === true时也进行跳转