### PR TITLE
feat: Add run production mode with docker-compose.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+.DS_Store
+node_modules/
+vendor/
+dist/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+**/*.log
+
+tests/**/coverage/
+tests/e2e/reports
+selenium-debug.log
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.local
+
+package-lock.json
+yarn.lock

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:12
 
 # Create app directory
 WORKDIR /usr/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:10
+
+# Create app directory
+WORKDIR /usr/app
+
+# Copy project files
+COPY . ./
+
+# Install app dependencies
+# A wildcard is used to ensure both package.json AND package-lock.json are copied
+# where available (npm@5+)
+RUN npm install \
+    && npm run build:prod
+# Build state files
+
+# Start builded application
+CMD npm run preview

--- a/README.es.md
+++ b/README.es.md
@@ -187,6 +187,13 @@ npm run lint
 npm run lint -- --fix
 ```
 
+## Contenedor Docker
+
+```bash
+# requiere permisos de superusuario del sistema operativo ('su' o 'sudo')
+docker-componer up
+```
+
 Vaya a [Documentación](https://panjiachen.github.io/vue-element-admin-site/guide/essentials/deploy.html) para mayor información
 
 ## Registro de Cambios

--- a/README.ja.md
+++ b/README.ja.md
@@ -183,6 +183,13 @@ npm run lint
 npm run lint -- --fix
 ```
 
+## Dockerコンテナ
+
+```bash
+＃オペレーティングシステムのスーパーユーザー権限が必要（ 'su'または 'sudo'）
+docker-compose up
+```
+
 詳細は [Documentation](https://panjiachen.github.io/vue-element-admin-site/guide/essentials/deploy.html) を参照してください。
 
 ## Changelog

--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ npm run lint
 npm run lint -- --fix
 ```
 
+## Docker Container
+
+```bash
+# requires superuser permissions of the operating system ('su' or 'sudo')
+docker-compose up
+```
+
 Refer to [Documentation](https://panjiachen.github.io/vue-element-admin-site/guide/essentials/deploy.html) for more information
 
 ## Changelog

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -205,6 +205,13 @@ npm run lint
 npm run lint -- --fix
 ```
 
+## Docker容器
+
+```bash
+# 需要操作系统的超级用户权限（“ su”或“ sudo”）
+docker-compose up
+```
+
 更多信息请参考 [使用文档](https://panjiachen.github.io/vue-element-admin-site/zh/)
 
 ## Changelog

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: '3.8'
 
 services:
   web-client:
@@ -17,4 +17,3 @@ services:
     tty: true
     ports:
       - 9526:9526 # Prod
-      # - 9527:9527 # Dev

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,20 @@
+version: '3.7'
+
+services:
+  web-client:
+    build:
+      context: .
+      dockerfile: ./Dockerfile
+    container_name: vue-element-admin
+    network_mode: bridge
+    build: .
+    volumes:
+      - /usr/app/
+      - /usr/app/node_modules
+    labels:
+      - app=vue-element-admin
+    stdin_open: true
+    tty: true
+    ports:
+      - 9526:9526 # Prod
+      # - 9527:9527 # Dev


### PR DESCRIPTION
Added running the application in production mode from a docker container, using docker compose, this allows different instances of application services with containers to be raised on the same host in a simple way.

Requires superuser (or administrator) permissions
```bash
doker-compose up
```

The tests were run in the following environment:
* Debian GNU / Linux 9.5 x64
* Docker version 19.03.11, build 42e35e61f3
* docker-compose version 1.23.2, build 1110ad01

The docker image that you download from the docker hub is node version 12, go to the following link to see information about the image:
https://hub.docker.com/layers/node/library/node/12/images/sha256-e08499460efdccaeb12b3f251863d26322168d2a8463241b52d81e5d06b42901?context=explore
