### PR TITLE
perf[chore]: remove preserveWhitespace config

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -81,17 +81,6 @@ module.exports = {
       })
       .end()
 
-    // set preserveWhitespace
-    config.module
-      .rule('vue')
-      .use('vue-loader')
-      .loader('vue-loader')
-      .tap(options => {
-        options.compilerOptions.preserveWhitespace = true
-        return options
-      })
-      .end()
-
     config
       .when(process.env.NODE_ENV !== 'development',
         config => {


### PR DESCRIPTION
preserveWhitespace Deprecated since vue@2.6

Recommend `whitespace: 'condense'`, it is the default config in new vue-cli https://github.com/vuejs/vue-cli/pull/3853

Detail: https://github.com/vuejs/vue/issues/9208#issuecomment-450012518