### PR TITLE
fix:修复当tag为active状态且不是affix标签 此时在affix标签上选择关闭全部时 页面不会跳转到lastView

### DIFF
--- a/src/layout/components/TagsView/index.vue
+++ b/src/layout/components/TagsView/index.vue
@@ -149,7 +149,7 @@ export default {
     },
     closeAllTags(view) {
       this.$store.dispatch('tagsView/delAllViews').then(({ visitedViews }) => {
-        if (this.affixTags.some(tag => tag.path === view.path)) {
+        if (this.affixTags.some(tag => tag.path === this.$route.path)) {
           return
         }
         this.toLastView(visitedViews, view)


### PR DESCRIPTION
this.affixTags.some(tag => tag.path === view.path)只要右击affix标签全部关闭 这个都会返回true，如果active状态的页签为非affix的话，此时页面不会跳转。  