### PR TITLE
fix: waves failed after adding handler

### DIFF
--- a/src/directive/waves/waves.js
+++ b/src/directive/waves/waves.js
@@ -61,7 +61,10 @@ export default {
     el.addEventListener('click', handleClick(el, binding), false)
   },
   update(el, binding) {
-    el.removeEventListener('click', el[context].removeHandle, false)
+    const removeHandler = el[context].removeHandle
+    setTimeout(_ => {
+      el.removeEventListener('click', removeHandler, false)
+    })
     el.addEventListener('click', handleClick(el, binding), false)
   },
   unbind(el) {


### PR DESCRIPTION
当用户给一个元素（如按钮元素）添加v-waves指令后，如果用户再给元素添加一个click事件handler，而这个handler在执行时触发了组件的update，那么按钮的波动效果就会失效。