### PR TITLE
feat: Update and replace runjs with taskfile.

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -1,15 +1,12 @@
-const { run } = require('runjs')
+const { sh } = require('tasksfile')
 const chalk = require('chalk')
 const config = require('../vue.config.js')
 const rawArgv = process.argv.slice(2)
 const args = rawArgv.join(' ')
 
+sh(`vue-cli-service build ${args}`)
+
 if (process.env.npm_config_preview || rawArgv.includes('--preview')) {
-  const report = rawArgv.includes('--report')
-
-  run(`vue-cli-service build ${args}`)
-
-  const port = 9526
   const publicPath = config.publicPath
 
   var connect = require('connect')
@@ -23,13 +20,14 @@ if (process.env.npm_config_preview || rawArgv.includes('--preview')) {
     })
   )
 
+  const port = 9526
   app.listen(port, function () {
     console.log(chalk.green(`> Preview at  http://localhost:${port}${publicPath}`))
-    if (report) {
+
+    const isWithReport = rawArgv.includes('--report')
+    if (isWithReport) {
       console.log(chalk.green(`> Report at  http://localhost:${port}${publicPath}report.html`))
     }
 
   })
-} else {
-  run(`vue-cli-service build ${args}`)
 }

--- a/package.json
+++ b/package.json
@@ -63,13 +63,13 @@
     "lint-staged": "8.1.5",
     "mockjs": "1.0.1-beta3",
     "plop": "2.3.0",
-    "runjs": "4.3.2",
     "sass": "1.26.2",
     "sass-loader": "8.0.2",
     "script-ext-html-webpack-plugin": "2.1.3",
     "serve-static": "1.13.2",
     "svg-sprite-loader": "4.1.3",
     "svgo": "1.2.0",
+    "tasksfile": "5.1.1",
     "vue-template-compiler": "2.6.10"
   },
   "browserslist": [


### PR DESCRIPTION

When installing the dependencies, the following message is received:
```shell
npm WARN deprecated runjs@4.4.2: This project has been renamed to 'tasksfile'. Install using 'npm install tasksfile' instead.
```


This was solved by replacing the dependency, runjs by taskfile.