### PR TITLE
fix: validLowerCase and validUpperCase the result return  incorrect

### DIFF
--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -33,6 +33,7 @@ export function validURL(url) {
  * @returns {Boolean}
  */
 export function validLowerCase(str) {
+  // https://www.coder.work/article/1041931
   if (str === undefined || str === null) return false
   const reg = /^[a-z]+$/
   return reg.test(str)
@@ -43,6 +44,7 @@ export function validLowerCase(str) {
  * @returns {Boolean}
  */
 export function validUpperCase(str) {
+  // https://www.coder.work/article/1041931
   if (str === undefined || str === null) return false
   const reg = /^[A-Z]+$/
   return reg.test(str)

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -33,6 +33,7 @@ export function validURL(url) {
  * @returns {Boolean}
  */
 export function validLowerCase(str) {
+  if (str === undefined || str === null) return false
   const reg = /^[a-z]+$/
   return reg.test(str)
 }
@@ -42,6 +43,7 @@ export function validLowerCase(str) {
  * @returns {Boolean}
  */
 export function validUpperCase(str) {
+  if (str === undefined || str === null) return false
   const reg = /^[A-Z]+$/
   return reg.test(str)
 }

--- a/tests/unit/utils/validate.spec.js
+++ b/tests/unit/utils/validate.spec.js
@@ -14,11 +14,13 @@ describe('Utils:validate', () => {
     expect(validLowerCase('abc')).toBe(true)
     expect(validLowerCase('Abc')).toBe(false)
     expect(validLowerCase('123abc')).toBe(false)
+    expect(validLowerCase()).toBe(false)
   })
   it('validUpperCase', () => {
     expect(validUpperCase('ABC')).toBe(true)
     expect(validUpperCase('Abc')).toBe(false)
     expect(validUpperCase('123ABC')).toBe(false)
+    expect(validUpperCase()).toBe(false)
   })
   it('validAlphabets', () => {
     expect(validAlphabets('ABC')).toBe(true)


### PR DESCRIPTION
https://github.com/PanJiaChen/vue-element-admin/blob/master/src/utils/validate.js#L35
https://github.com/PanJiaChen/vue-element-admin/blob/master/src/utils/validate.js#L44
validLowerCase and validUpperCase function the result return is incorrect when function have no params or params is null