### PR TITLE
Adding { SameSite: 'Lax' } to Cookies.set attributes

### DIFF
--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -14,13 +14,13 @@ const mutations = {
     state.sidebar.opened = !state.sidebar.opened
     state.sidebar.withoutAnimation = false
     if (state.sidebar.opened) {
-      Cookies.set('sidebarStatus', 1)
+      Cookies.set('sidebarStatus', 1, { SameSite: 'Lax' })
     } else {
-      Cookies.set('sidebarStatus', 0)
+      Cookies.set('sidebarStatus', 0, { SameSite: 'Lax' })
     }
   },
   CLOSE_SIDEBAR: (state, withoutAnimation) => {
-    Cookies.set('sidebarStatus', 0)
+    Cookies.set('sidebarStatus', 0, { SameSite: 'Lax' })
     state.sidebar.opened = false
     state.sidebar.withoutAnimation = withoutAnimation
   },
@@ -29,7 +29,7 @@ const mutations = {
   },
   SET_SIZE: (state, size) => {
     state.size = size
-    Cookies.set('size', size)
+    Cookies.set('size', size, { SameSite: 'Lax' })
   }
 }
 

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -7,7 +7,7 @@ export function getToken() {
 }
 
 export function setToken(token) {
-  return Cookies.set(TokenKey, token)
+  return Cookies.set(TokenKey, token, { SameSite: 'Lax' })
 }
 
 export function removeToken() {


### PR DESCRIPTION
By Default js-cookie set `SameSite` to `None` and reference to: [SameSite cookies](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite), 
I've added `{ SameSite: 'Lax' }` to `Cookies.set` attributes after validating that `js-cookie` support it via this [release](https://github.com/js-cookie/js-cookie/releases/tag/v2.2.0),