### PR TITLE
#3289 add base path to match publicPath

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -389,6 +389,7 @@ export const asyncRoutes = [
 
 const createRouter = () => new Router({
   // mode: 'history', // require service support
+  // base: process.env.VUE_APP_SRC, // public
   scrollBehavior: () => ({ y: 0 }),
   routes: constantRoutes
 })


### PR DESCRIPTION
fixes breaking to 404 page in history mode when publicPath sub path is set