### PR TITLE
Replace CSS calc with box-sizing for better compatibility.

### DIFF
--- a/src/layout/components/AppMain.vue
+++ b/src/layout/components/AppMain.vue
@@ -24,8 +24,8 @@ export default {
 
 <style lang="scss" scoped>
 .app-main {
-  /* 50= navbar  50  */
-  min-height: calc(100vh - 50px);
+  min-height: 100vh;
+  box-sizing: border-box;
   width: 100%;
   position: relative;
   overflow: hidden;
@@ -36,11 +36,6 @@ export default {
 }
 
 .hasTagsView {
-  .app-main {
-    /* 84 = navbar + tags-view = 50 + 34 */
-    min-height: calc(100vh - 84px);
-  }
-
   .fixed-header+.app-main {
     padding-top: 84px;
   }


### PR DESCRIPTION
我的项目中，这里的 calc 导致内部 absolute 定位元素大小错乱。此外，box-sizing: border-box 相对于 calc 有更好的兼容性和性能，故建议使用 box-sizing: border-box 取代这里的 calc。