### PR TITLE
没有权限或者退出登录跳转到登录页面时当前页面url的query未设置

### DIFF
--- a/src/layout/components/Navbar.vue
+++ b/src/layout/components/Navbar.vue
@@ -76,7 +76,8 @@ export default {
     },
     async logout() {
       await this.$store.dispatch('user/logout')
-      this.$router.push(`/login?redirect=${this.$route.fullPath}`)
+      const { path, query } = this.$route
+      this.$router.push({ path: '/login', query: { redirect: path, ...query }})
     }
   }
 }

--- a/src/permission.js
+++ b/src/permission.js
@@ -49,7 +49,7 @@ router.beforeEach(async(to, from, next) => {
           // remove token and go to login page to re-login
           await store.dispatch('user/resetToken')
           Message.error(error || 'Has Error')
-          next(`/login?redirect=${to.path}`)
+          next({ path: '/login', query: { redirect: to.path, ...to.query }})
           NProgress.done()
         }
       }
@@ -62,7 +62,7 @@ router.beforeEach(async(to, from, next) => {
       next()
     } else {
       // other pages that do not have permission to access are redirected to the login page.
-      next(`/login?redirect=${to.path}`)
+      next({ path: '/login', query: { redirect: to.path, ...to.query }})
       NProgress.done()
     }
   }


### PR DESCRIPTION
没有权限或者点击退出登录跳转到登录页面的时候，当前页面url的query没有加到登录页面的url上，导致重新登录成功后，页面跳转到之前的页面后query丢失，可能使某些依赖query参数的页面显示不正确。