### PR TITLE
destroyed => beforeDestroy

### DIFF
--- a/src/components/Tinymce/index.vue
+++ b/src/components/Tinymce/index.vue
@@ -98,7 +98,7 @@ export default {
   deactivated() {
     this.destroyTinymce()
   },
-  destroyed() {
+  beforeDestroy() {
     this.destroyTinymce()
   },
   methods: {


### PR DESCRIPTION
destroyed 实例已销毁，无法访问 this.fullscreen