### PR TITLE
修复token过期或错误后 弹框拦截不下来 控制台报很多错的问题

### DIFF
--- a/src/utils/request.js
+++ b/src/utils/request.js
@@ -3,6 +3,20 @@ import { MessageBox, Message } from 'element-ui'
 import store from '@/store'
 import { getToken } from '@/utils/auth'
 
+function confirmReLogin() {
+  return new Promise((resolve, reject) => {
+    MessageBox.confirm('You have been logged out, you can cancel to stay on this page, or log in again', 'Confirm logout', {
+      confirmButtonText: 'Re-Login',
+      cancelButtonText: 'Cancel',
+      type: 'warning'
+    }).then(() => {
+      store.dispatch('user/resetToken').then(() => {
+        location.reload()
+      })
+    })
+  })
+}
+
 // create an axios instance
 const service = axios.create({
   baseURL: process.env.VUE_APP_BASE_API, // url = base url + request url
@@ -42,30 +56,20 @@ service.interceptors.response.use(
    * Here is just an example
    * You can also judge the status by HTTP Status Code
    */
-  response => {
+  async response => {
     const res = response.data
 
-    // if the custom code is not 20000, it is judged as an error.
-    if (res.code !== 20000) {
+    // 50008: Illegal token; 50012: Other clients logged in; 50014: Token expired;
+    if (res.code === 50008 || res.code === 50012 || res.code === 50014) {
+      // to re-login
+      await confirmReLogin()
+    } else if (res.code !== 20000) {
+      // if the custom code is not 20000, it is judged as an error.
       Message({
         message: res.message || 'Error',
         type: 'error',
         duration: 5 * 1000
       })
-
-      // 50008: Illegal token; 50012: Other clients logged in; 50014: Token expired;
-      if (res.code === 50008 || res.code === 50012 || res.code === 50014) {
-        // to re-login
-        MessageBox.confirm('You have been logged out, you can cancel to stay on this page, or log in again', 'Confirm logout', {
-          confirmButtonText: 'Re-Login',
-          cancelButtonText: 'Cancel',
-          type: 'warning'
-        }).then(() => {
-          store.dispatch('user/resetToken').then(() => {
-            location.reload()
-          })
-        })
-      }
       return Promise.reject(new Error(res.message || 'Error'))
     } else {
       return res


### PR DESCRIPTION
之前代码token过期或错误后 弹框拦截不下来 并且控制台报很多错的问题，现在给弹框加了个async/await 拦截