### PR TITLE
SVG组件use标签添加href属性

### DIFF
--- a/src/components/SvgIcon/index.vue
+++ b/src/components/SvgIcon/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="isExternal" :style="styleExternalIcon" class="svg-external-icon svg-icon" v-on="$listeners" />
   <svg v-else :class="svgClass" aria-hidden="true" v-on="$listeners">
-    <use :xlink:href="iconName" />
+    <use :xlink:href="iconName" :href="iconName" />
   </svg>
 </template>
 


### PR DESCRIPTION
xlink:href属性已不推荐使用，目前可能处于删除的过程或者可能只是为了兼容性的目的而保留。SVG2中不需要xlink命名空间，可以使用href代替

[MDN xlink:href文档](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/xlink:href)