### PR TITLE
fix issue4161 navbar show name error

### DIFF
--- a/src/permission.js
+++ b/src/permission.js
@@ -56,7 +56,7 @@ router.beforeEach(async(to, from, next) => {
     }
   } else {
     /* has no token*/
-
+store.commit('user/SET_ROLES', [])
     if (whiteList.indexOf(to.path) !== -1) {
       // in the free login whitelist, go directly
       next()


### PR DESCRIPTION
Bug report（问题描述）
用用户1登录系统，手动在控制台去除cookie信息后,在地址栏上跳转到login页面，用用户2登录，结果navbar显示的用户名字还是用户1的

Steps to reproduce（问题复现步骤）
1.使用admin账户登录系统
![image](https://github.com/PanJiaChen/vue-element-admin/assets/77432113/5cfe75eb-f058-4176-88e9-db80247f0c7b)
2.控制台手动去除cookie中的token,地址栏访问到login页面
![image](https://github.com/PanJiaChen/vue-element-admin/assets/77432113/4dd1de42-2182-48ef-9a75-78d11fae0d65)
3.使用editor账户登录系统
![image](https://github.com/PanJiaChen/vue-element-admin/assets/77432113/6d611376-36a3-4b2f-a6cf-66af343b7220)
4.发现navbar显示的还是admin的用户名字
![image](https://github.com/PanJiaChen/vue-element-admin/assets/77432113/95a5854e-d717-435b-a44c-25f971fe3e67)
Other relevant information（格外信息）
Your OS: win10
Node.js version: 14.17.6
vue-element-admin version: 4.4.0