### PR TITLE
Fix children hidden

### DIFF
--- a/src/layout/components/Sidebar/SidebarItem.vue
+++ b/src/layout/components/Sidebar/SidebarItem.vue
@@ -62,12 +62,12 @@ export default {
         if (item.hidden) {
           return false
         } else {
-	  // Recursive children, determine whether multi-layer submenus need to be hidden.
-	  if (item.hidden) {
-	    return this.hasOneShowingChild(item.children, item)
-	  }
+      	  // Recursive children, determine whether multi-layer submenus need to be hidden.
+      	  if (item.hidden) {
+      	    return this.hasOneShowingChild(item.children, item)
+      	  }
           // Temp set(will be used if only has one showing child)
-	  this.onlyOneChild = item
+      	  this.onlyOneChild = item
           return true
         }
       })


### PR DESCRIPTION
Fixed an issue where the hidden judgment of menus above the second level is invalid, resulting in blank spaces and arrow icons appearing in the menu.