### PR TITLE
上传图片时只能使用默认名称的问题

### DIFF
--- a/src/components/ImageCropper/index.vue
+++ b/src/components/ImageCropper/index.vue
@@ -225,6 +225,7 @@ export default {
     }
   },
   data() {
+    let fileName
     const { imgFormat, langType, langExt, width, height } = this
     let isSupported = true
     const allowImgFormat = ['jpg', 'png']
@@ -478,6 +479,7 @@ export default {
     },
     // 设置图片源
     setSourceImg(file) {
+      this.fileName = file.name.substr(0,file.name.lastIndexOf('.'))
       const fr = new FileReader()
       fr.onload = e => {
         this.sourceImgUrl = fr.result
@@ -773,7 +775,8 @@ export default {
       fmData.append(
         field,
         data2blob(createImgUrl, mime),
-        field + '.' + imgFormat
+        //field + '.' + imgFormat
+        this.fileName + '.' + imgFormat
       )
       // 添加其他参数
       if (typeof params === 'object' && params) {


### PR DESCRIPTION
上传图片时默认只能使用file指定的名称，而不能使用本地的图片名称
修改后上传的图片名称即为本地的图片名称，而不是file中指定的固定名称了