### PR TITLE
fix: Update Export2Excel.js (#4191)

### DIFF
--- a/src/vendor/Export2Excel.js
+++ b/src/vendor/Export2Excel.js
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import { saveAs } from 'file-saver'
-import XLSX from 'xlsx'
+import * as XLSX from 'xlsx'
 
 function generateArray(table) {
   var out = [];


### PR DESCRIPTION
`Export2Excel.js` 代码第 83 行报错，找不到属性 `XLSX.utils`