### PR TITLE
修改了依赖tui-editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "screenfull": "4.2.0",
     "script-loader": "0.7.2",
     "sortablejs": "1.8.4",
-    "tui-editor": "1.3.3",
+    "@toast-ui/editor": "3.1.3",
     "vue": "2.6.10",
     "vue-count-to": "1.0.13",
     "vue-router": "3.0.2",


### PR DESCRIPTION
解决克隆项目后无法成功安装依赖的问题：
Steps to reproduce（问题复现步骤）
克隆项目到本地电脑
yarn
有网络超时的报错出现
fatal: unable to access 'https://github.com/nhn/raphael.git/': LibreSSL SSL_read: error:02FFF03C:system library:func(4095):Operation timed out, errno 60 at ProcessTermError.ExtendableBuiltin (/usr/local/lib/node_modules/yarn/lib/cli.js:721:66) at ProcessTermError.MessageError (/usr/local/lib/node_modules/yarn/lib/cli.js:750:123) at new ProcessTermError (/usr/local/lib/node_modules/yarn/lib/cli.js:790:113) at ChildProcess.<anonymous> (/usr/local/lib/node_modules/yarn/lib/cli.js:25787:17) at ChildProcess.emit (node:events:513:28) at maybeClose (node:internal/child_process:1093:16) at Process.ChildProcess._handle.onexit (node:internal/child_process:302:5)
Screenshot or Gif（截图或动态图）
![image](https://github.com/user-attachments/assets/791904df-0cf8-4e6d-b98d-5df33d99a556)



解决办法：
项目依赖的 tui-editor 插件包更换了包名，导致无法正常安装成功，一直卡在这里，因此解决办法很简单，更换项目package.json里面 tui-editor 为@toast-ui/editor 即可，我提交的代码中对错误进行了修改